### PR TITLE
fix(balance_update): disable a coin updates now the main balance

### DIFF
--- a/src/atomicdex/app.cpp
+++ b/src/atomicdex/app.cpp
@@ -158,6 +158,7 @@ namespace atomic_dex
             {
                 system_manager_.get_system<wallet_page>().set_current_ticker("KMD");
             }
+            this->dispatcher_.trigger<update_portfolio_values>(false);
         }
 
         return false;


### PR DESCRIPTION
Solves #500 

- update_portfolio_value event was not triggered when disabling a coin.