### PR TITLE
Fix combobox was changing when list changes at 5.15.1

### DIFF
--- a/atomic_defi_design/qml/Exchange/Trade/DexComboBox.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/DexComboBox.qml
@@ -105,11 +105,11 @@ DefaultComboBox {
 
                 Keys.onPressed: {
                     if(event.key === Qt.Key_Return) {
-                        if(ticker_list.length > 0) {
+                        if(control.count > 0) {
                             control.currentIndex = 0
-                            popup.close()
-                            event.accepted = true
                         }
+                        popup.close()
+                        event.accepted = true
                     }
                 }
             }

--- a/atomic_defi_design/qml/Exchange/Trade/DexComboBox.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/DexComboBox.qml
@@ -105,9 +105,11 @@ DefaultComboBox {
 
                 Keys.onPressed: {
                     if(event.key === Qt.Key_Return) {
-                        control.currentIndex = 0
-                        popup.close()
-                        event.accepted = true
+                        if(ticker_list.length > 0) {
+                            control.currentIndex = 0
+                            popup.close()
+                            event.accepted = true
+                        }
                     }
                 }
             }

--- a/atomic_defi_design/qml/Exchange/Trade/TickerSelector.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/TickerSelector.qml
@@ -31,25 +31,28 @@ RowLayout {
 
         valueRole: "ticker"
 
+        // Indicates user input, when list changes, index stays the same so we know it's not user input
         property bool index_changed: false
 
         onCurrentIndexChanged: combo.index_changed = true
 
-        onDisplayTextChanged: {
-            if(currentText.indexOf(ticker) === -1) {
-                const target_index = indexOfValue(ticker)
-                if(currentIndex !== target_index) {
-                    if(!combo.index_changed) {
+        onCurrentValueChanged: {
+            // User input
+            if(combo.index_changed) {
+                combo.index_changed = false
+                // Set the ticker
+                if(currentValue !== undefined) 
+                    setPair(left_side, currentValue)
+            }
+            // List change
+            else {
+                // Correct the index
+                if(currentText.indexOf(ticker) === -1) {
+                    const target_index = indexOfValue(ticker)
+                    if(currentIndex !== target_index) 
                         currentIndex = target_index
-                    }
-                    else combo.index_changed = false
                 }
             }
-        }
-
-        onCurrentValueChanged: {
-            combo.index_changed = false
-            if(currentValue !== undefined) setPair(left_side, currentValue)
         }
 
         Layout.fillWidth: true


### PR DESCRIPTION
Qt changed ComboBox functionality at 5.15.1, however value changes when list is updated and the index stays the same.

Fixing this:
![image](https://user-images.githubusercontent.com/6732486/97589376-7d5c5700-1a0e-11eb-933c-96c46d580937.png)

If index changes, we know it's user input. 

So,
- if index changes, then value changes, we allow this change.
- if index does not change, but value changes, then we change the index to the old ticker, because we don't want value to change.
