### PR TITLE
Fix CheckBoxes become black after entering input to the search at Enable Coin Modal

### DIFF
--- a/atomic_defi_design/assets/languages/atomic_defi_en.ts
+++ b/atomic_defi_design/assets/languages/atomic_defi_en.ts
@@ -2275,11 +2275,6 @@
         <source>Privacy</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../qml/Sidebar/SidebarBottom.qml" line="40"/>
-        <source>Light UI</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>SidebarCenter</name>

--- a/atomic_defi_design/assets/languages/atomic_defi_fr.ts
+++ b/atomic_defi_design/assets/languages/atomic_defi_fr.ts
@@ -2275,11 +2275,6 @@
         <source>Privacy</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../qml/Sidebar/SidebarBottom.qml" line="40"/>
-        <source>Light UI</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>SidebarCenter</name>

--- a/atomic_defi_design/assets/languages/atomic_defi_ru.ts
+++ b/atomic_defi_design/assets/languages/atomic_defi_ru.ts
@@ -2284,11 +2284,6 @@
         <source>Privacy</source>
         <translation>Скрыть баланс</translation>
     </message>
-    <message>
-        <location filename="../../qml/Sidebar/SidebarBottom.qml" line="40"/>
-        <source>Light UI</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>SidebarCenter</name>

--- a/atomic_defi_design/assets/languages/atomic_defi_tr.ts
+++ b/atomic_defi_design/assets/languages/atomic_defi_tr.ts
@@ -2266,11 +2266,6 @@
         <source>Privacy</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../qml/Sidebar/SidebarBottom.qml" line="40"/>
-        <source>Light UI</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>SidebarCenter</name>

--- a/atomic_defi_design/qml/Components/CoinMenu.qml
+++ b/atomic_defi_design/qml/Components/CoinMenu.qml
@@ -5,6 +5,11 @@ import QtQuick.Controls.Universal 2.15
 import "../Constants"
 
 Menu {
+    Universal.theme: Style.dark_theme ? Universal.Dark : Universal.Light
+    Universal.accent: Style.colorQtThemeAccent
+    Universal.foreground: Style.colorQtThemeForeground
+    Universal.background: Style.colorQtThemeBackground
+
     // Ugly but required hack for automatic menu width, otherwise long texts are being cut
     width: {
         let result = 0

--- a/atomic_defi_design/qml/Components/DefaultBusyIndicator.qml
+++ b/atomic_defi_design/qml/Components/DefaultBusyIndicator.qml
@@ -3,9 +3,15 @@ import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
 
 import QtGraphicalEffects 1.0
+import QtQuick.Controls.Universal 2.15
 import "../Constants"
 
 BusyIndicator {
+    Universal.theme: Style.dark_theme ? Universal.Dark : Universal.Light
+    Universal.accent: Style.colorQtThemeAccent
+    Universal.foreground: Style.colorQtThemeForeground
+    Universal.background: Style.colorQtThemeBackground
+
     id: control
     implicitWidth: 48
     implicitHeight: 48

--- a/atomic_defi_design/qml/Components/DefaultCheckBox.qml
+++ b/atomic_defi_design/qml/Components/DefaultCheckBox.qml
@@ -5,6 +5,11 @@ import QtQuick.Controls.Universal 2.15
 import "../Constants"
 
 CheckBox {
+    Universal.theme: Style.dark_theme ? Universal.Dark : Universal.Light
+    Universal.accent: Style.colorQtThemeAccent
+    Universal.foreground: Style.colorQtThemeForeground
+    Universal.background: Style.colorQtThemeBackground
+
     font.family: Style.font_family
 
     DefaultMouseArea {

--- a/atomic_defi_design/qml/Components/DefaultComboBox.qml
+++ b/atomic_defi_design/qml/Components/DefaultComboBox.qml
@@ -9,6 +9,11 @@ import "../Constants"
 ComboBox {
     id: control
 
+    Universal.theme: Style.dark_theme ? Universal.Dark : Universal.Light
+    Universal.accent: Style.colorQtThemeAccent
+    Universal.foreground: Style.colorQtThemeForeground
+    Universal.background: Style.colorQtThemeBackground
+
     font.family: Style.font_family
 
     property color lineHoverColor: Style.colorTheme5

--- a/atomic_defi_design/qml/Components/DefaultSwitch.qml
+++ b/atomic_defi_design/qml/Components/DefaultSwitch.qml
@@ -5,6 +5,11 @@ import QtQuick.Controls.Universal 2.15
 import "../Constants"
 
 Switch {
+    Universal.theme: Style.dark_theme ? Universal.Dark : Universal.Light
+    Universal.accent: Style.colorQtThemeAccent
+    Universal.foreground: Style.colorQtThemeForeground
+    Universal.background: Style.colorQtThemeBackground
+
     DefaultMouseArea {
         anchors.fill: parent
         acceptedButtons: Qt.NoButton


### PR DESCRIPTION
We are using the Universal theme, the colors are set in a separate file, independent from the QML code. 

Since I was implementing the light theme, I removed those static color codes. Defined them in the top level QML code, at the application window.

```qml
    Universal.theme: Style.dark_theme ? Universal.Dark : Universal.Light
    Universal.accent: Style.colorQtThemeAccent
    Universal.foreground: Style.colorQtThemeForeground
    Universal.background: Style.colorQtThemeBackground
```

It worked fine. However at the Enable Coin Modal, if you filter the coins list by entering text in the search bar, all the checkboxes and their texts become black, means that theme colors are ignored.

I solved it by copying those same lines to my custom wrapper components of stock Qt components such as `CheckBox`.

So we better test it by interacting the application, seems like Qt has a bug somehow. Colors work at first launch but breaks after interaction. It should be fine now.
