### PR TITLE
Added GETH to default coins

### DIFF
--- a/assets/config/0.3.1-coins.json
+++ b/assets/config/0.3.1-coins.json
@@ -1344,5 +1344,22 @@
     "type": "UTXO",
     "active": false,
     "currently_enabled": false
-  }
+  },
+    "GETH": {
+    "active": false,
+    "coin": "GETH",
+    "coingecko_id": "test-coin",
+    "coinpaprika_id": "test-coin",
+    "currently_enabled": false,
+    "eth_nodes": [
+      "http://eth1.cipig.net:8555",
+      "http://eth2.cipig.net:8555",
+      "http://eth3.cipig.net:8555"
+    ],
+    "explorer_url": [
+      "https://etherscan.io/"
+    ],
+    "type": "ERC-20",
+    "name": "Guarded Ether"
+  },
 }


### PR DESCRIPTION
GETH is Guarded Ether. Since ETH2.0 staking rewards cannot be withdrawn at this stage Guarda wallet recently implemented of a 1:1 ETH token that is specifically paid out to their users who are within their Staking pool. So this can be withdrawn from Staking rewards and when withdrawing is enabled, can be used to claim ETH from the pool at 1:1 ratio.