### PR TITLE
update mm2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,13 +106,13 @@ endif ()
 ##! We fetch our dependencies
 if (APPLE)
     FetchContent_Declare(mm2
-            URL https://github.com/KomodoPlatform/atomicDEX-API/releases/download/beta-2.1.2883/mm2-014c4eab4-Darwin-Release.zip)
+            URL https://github.com/KomodoPlatform/atomicDEX-API/releases/download/beta-2.1.2940/mm2-3cc42ed43-Darwin-Release.zip)
 elseif (UNIX AND NOT APPLE)
     FetchContent_Declare(mm2
-            URL https://github.com/KomodoPlatform/atomicDEX-API/releases/download/beta-2.1.2883/mm2-014c4eab4-Linux-Release.zip)
+            URL https://github.com/KomodoPlatform/atomicDEX-API/releases/download/beta-2.1.2940/mm2-3cc42ed43-Linux-Release.zip)
 else ()
     FetchContent_Declare(mm2
-            URL https://github.com/KomodoPlatform/atomicDEX-API/releases/download/beta-2.1.2883/mm2-014c4eab4-Windows_NT-Release.zip)
+            URL https://github.com/KomodoPlatform/atomicDEX-API/releases/download/beta-2.1.2940/mm2-3cc42ed43-Windows_NT-Release.zip)
 endif ()
 
 FetchContent_Declare(qmaterial URL https://github.com/KomodoPlatform/Qaterial/archive/master.zip)


### PR DESCRIPTION
fixes `"error": "rpc:237] lp_commands:85] lp_coins:706] unknown variant `QTUM`, expected one of `UTXO`, `QRC20`, `ETH`, `ERC20`"` when enabling QTUM