### PR TITLE
feat(api): continue the split

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,7 @@ target_sources(atomicdex-desktop_shared_deps PRIVATE
         ##! Config
         ${CMAKE_SOURCE_DIR}/src/atomicdex/config/app.cfg.cpp
         ${CMAKE_SOURCE_DIR}/src/atomicdex/config/coins.cfg.cpp
+        ${CMAKE_SOURCE_DIR}/src/atomicdex/config/electrum.cfg.cpp
         ${CMAKE_SOURCE_DIR}/src/atomicdex/config/wallet.cfg.cpp
         ${CMAKE_SOURCE_DIR}/src/atomicdex/config/addressbook.cfg.cpp
 
@@ -210,6 +211,7 @@ target_sources(atomicdex-desktop_shared_deps PRIVATE
         ${CMAKE_SOURCE_DIR}/src/atomicdex/api/mm2/rpc.trade.preimage.cpp
         ${CMAKE_SOURCE_DIR}/src/atomicdex/api/mm2/rpc.max.taker.vol.cpp
         ${CMAKE_SOURCE_DIR}/src/atomicdex/api/mm2/rpc.enable.cpp
+        ${CMAKE_SOURCE_DIR}/src/atomicdex/api/mm2/rpc.electrum.cpp
         ${CMAKE_SOURCE_DIR}/src/atomicdex/api/mm2/fraction.cpp
         ${CMAKE_SOURCE_DIR}/src/atomicdex/api/coinpaprika/coinpaprika.cpp
         ${CMAKE_SOURCE_DIR}/src/atomicdex/api/coingecko/coingecko.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,7 @@ target_sources(atomicdex-desktop_shared_deps PRIVATE
         ${CMAKE_SOURCE_DIR}/src/atomicdex/api/mm2/rpc.max.taker.vol.cpp
         ${CMAKE_SOURCE_DIR}/src/atomicdex/api/mm2/rpc.enable.cpp
         ${CMAKE_SOURCE_DIR}/src/atomicdex/api/mm2/rpc.electrum.cpp
+        ${CMAKE_SOURCE_DIR}/src/atomicdex/api/mm2/rpc.balance.cpp
         ${CMAKE_SOURCE_DIR}/src/atomicdex/api/mm2/fraction.cpp
         ${CMAKE_SOURCE_DIR}/src/atomicdex/api/coinpaprika/coinpaprika.cpp
         ${CMAKE_SOURCE_DIR}/src/atomicdex/api/coingecko/coingecko.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,7 @@ target_sources(atomicdex-desktop_shared_deps PRIVATE
         ${CMAKE_SOURCE_DIR}/src/atomicdex/api/mm2/mm2.cpp
         ${CMAKE_SOURCE_DIR}/src/atomicdex/api/mm2/rpc.trade.preimage.cpp
         ${CMAKE_SOURCE_DIR}/src/atomicdex/api/mm2/rpc.max.taker.vol.cpp
+        ${CMAKE_SOURCE_DIR}/src/atomicdex/api/mm2/rpc.enable.cpp
         ${CMAKE_SOURCE_DIR}/src/atomicdex/api/mm2/fraction.cpp
         ${CMAKE_SOURCE_DIR}/src/atomicdex/api/coinpaprika/coinpaprika.cpp
         ${CMAKE_SOURCE_DIR}/src/atomicdex/api/coingecko/coingecko.cpp

--- a/src/atomicdex/api/mm2/mm2.cpp
+++ b/src/atomicdex/api/mm2/mm2.cpp
@@ -159,33 +159,6 @@ namespace
     }
 } // namespace
 
-//! Implementation RPC [enable]
-namespace mm2::api
-{
-    //! Serialization
-    void
-    to_json(nlohmann::json& j, const enable_request& cfg)
-    {
-        j["coin"] = cfg.coin_name;
-        if (cfg.coin_type == CoinType::ERC20)
-        {
-            j["gas_station_url"]       = cfg.gas_station_url;
-            j["swap_contract_address"] = cfg.erc_swap_contract_address;
-            j["urls"]                  = cfg.urls;
-        }
-        j["tx_history"] = cfg.with_tx_history;
-    }
-
-    //! Deserialization
-    void
-    from_json(const nlohmann::json& j, enable_answer& cfg)
-    {
-        j.at("address").get_to(cfg.address);
-        j.at("balance").get_to(cfg.balance);
-        j.at("result").get_to(cfg.result);
-    }
-} // namespace mm2::api
-
 //! Implementation RPC [electrum]
 namespace mm2::api
 {

--- a/src/atomicdex/api/mm2/mm2.cpp
+++ b/src/atomicdex/api/mm2/mm2.cpp
@@ -159,32 +159,6 @@ namespace
     }
 } // namespace
 
-//! Implementation RPC [electrum]
-namespace mm2::api
-{
-    //! Serialization
-    void
-    to_json(nlohmann::json& j, const electrum_request& cfg)
-    {
-        j["coin"]       = cfg.coin_name;
-        j["servers"]    = cfg.servers;
-        j["tx_history"] = cfg.with_tx_history;
-        if (cfg.coin_type == CoinType::QRC20)
-        {
-            j["swap_contract_address"] = cfg.is_testnet ? cfg.testnet_qrc_swap_contract_address : cfg.mainnet_qrc_swap_contract_address;
-        }
-    }
-
-    //! Deserialization
-    void
-    from_json(const nlohmann::json& j, electrum_answer& cfg)
-    {
-        j.at("address").get_to(cfg.address);
-        j.at("balance").get_to(cfg.balance);
-        j.at("result").get_to(cfg.result);
-    }
-} // namespace mm2::api
-
 //! Implementation RPC [disable_coin]
 namespace mm2::api
 {

--- a/src/atomicdex/api/mm2/mm2.cpp
+++ b/src/atomicdex/api/mm2/mm2.cpp
@@ -186,25 +186,6 @@ namespace mm2::api
 namespace mm2::api
 {
     void
-    to_json(nlohmann::json& j, const balance_request& cfg)
-    {
-        j["coin"] = cfg.coin;
-    }
-
-    void
-    from_json(const nlohmann::json& j, balance_answer& cfg)
-    {
-        j.at("address").get_to(cfg.address);
-        j.at("balance").get_to(cfg.balance);
-        cfg.balance = atomic_dex::utils::adjust_precision(cfg.balance);
-        j.at("coin").get_to(cfg.coin);
-        if (cfg.coin == "BCH")
-        {
-            cfg.address = cfg.address.substr(sizeof("bitcoincash"));
-        }
-    }
-
-    void
     from_json(const nlohmann::json& j, fee_regular_coin& cfg)
     {
         j.at("amount").get_to(cfg.amount);

--- a/src/atomicdex/api/mm2/mm2.hpp
+++ b/src/atomicdex/api/mm2/mm2.hpp
@@ -102,24 +102,6 @@ namespace mm2::api
     recover_funds_of_swap_answer rpc_recover_funds(recover_funds_of_swap_request&& request, std::shared_ptr<t_http_client> mm2_client);
 
 
-    struct balance_request
-    {
-        std::string coin;
-    };
-
-    struct balance_answer
-    {
-        std::string address;
-        std::string balance;
-        std::string coin;
-        int         rpc_result_code;
-        std::string raw_result;
-    };
-
-    void to_json(nlohmann::json& j, const balance_request& cfg);
-
-    void from_json(const nlohmann::json& j, balance_answer& cfg);
-
     struct trade_fee_request
     {
         std::string coin;
@@ -643,8 +625,6 @@ namespace mm2::api
 
 namespace atomic_dex
 {
-    using t_balance_request         = ::mm2::api::balance_request;
-    using t_balance_answer          = ::mm2::api::balance_answer;
     using t_buy_request             = ::mm2::api::buy_request;
     using t_my_orders_answer        = ::mm2::api::my_orders_answer;
     using t_sell_request            = ::mm2::api::sell_request;

--- a/src/atomicdex/api/mm2/mm2.hpp
+++ b/src/atomicdex/api/mm2/mm2.hpp
@@ -46,30 +46,7 @@ namespace mm2::api
 
     std::string rpc_version();
 
-    //! Only for erc 20
-    struct enable_request
-    {
-        std::string              coin_name;
-        std::vector<std::string> urls;
-        CoinType                 coin_type;
-        const std::string        erc_swap_contract_address{"0x8500AFc0bc5214728082163326C2FF0C73f4a871"};
-        std::string              gas_station_url{"https://ethgasstation.info/json/ethgasAPI.json"};
-        std::string              type; ///< QRC-20 ?
-        bool                     with_tx_history{true};
-    };
 
-    void to_json(nlohmann::json& j, const enable_request& cfg);
-
-    struct enable_answer
-    {
-        std::string address;
-        std::string balance;
-        std::string result;
-        std::string raw_result;
-        int         rpc_result_code;
-    };
-
-    void from_json(const nlohmann::json& j, const enable_answer& cfg);
 
     struct electrum_request
     {
@@ -705,7 +682,6 @@ namespace atomic_dex
     using t_orderbook_request       = ::mm2::api::orderbook_request;
     using t_orderbook_answer        = ::mm2::api::orderbook_answer;
     using t_electrum_request        = ::mm2::api::electrum_request;
-    using t_enable_request          = ::mm2::api::enable_request;
     using t_disable_coin_request    = ::mm2::api::disable_coin_request;
     using t_tx_history_request      = ::mm2::api::tx_history_request;
     using t_my_recent_swaps_answer  = ::mm2::api::my_recent_swaps_answer;

--- a/src/atomicdex/api/mm2/mm2.hpp
+++ b/src/atomicdex/api/mm2/mm2.hpp
@@ -46,32 +46,6 @@ namespace mm2::api
 
     std::string rpc_version();
 
-
-
-    struct electrum_request
-    {
-        std::string                              coin_name;
-        std::vector<atomic_dex::electrum_server> servers;
-        CoinType                                 coin_type;
-        bool                                     is_testnet{false};
-        bool                                     with_tx_history{true};
-        const std::string                        testnet_qrc_swap_contract_address{"0xba8b71f3544b93e2f681f996da519a98ace0107a"};
-        const std::string                        mainnet_qrc_swap_contract_address{"0x2f754733acd6d753731c00fee32cb484551cc15d"};
-    };
-
-    struct electrum_answer
-    {
-        std::string address;
-        std::string balance;
-        std::string result;
-        int         rpc_result_code;
-        std::string raw_result;
-    };
-
-    void to_json(nlohmann::json& j, const electrum_request& cfg);
-
-    void from_json(const nlohmann::json& j, electrum_answer& answer);
-
     struct disable_coin_request
     {
         std::string coin;
@@ -681,7 +655,6 @@ namespace atomic_dex
     using t_broadcast_request       = ::mm2::api::send_raw_transaction_request;
     using t_orderbook_request       = ::mm2::api::orderbook_request;
     using t_orderbook_answer        = ::mm2::api::orderbook_answer;
-    using t_electrum_request        = ::mm2::api::electrum_request;
     using t_disable_coin_request    = ::mm2::api::disable_coin_request;
     using t_tx_history_request      = ::mm2::api::tx_history_request;
     using t_my_recent_swaps_answer  = ::mm2::api::my_recent_swaps_answer;

--- a/src/atomicdex/api/mm2/rpc.balance.cpp
+++ b/src/atomicdex/api/mm2/rpc.balance.cpp
@@ -1,0 +1,44 @@
+/******************************************************************************
+ * Copyright © 2013-2021 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+//! Deps
+#include <nlohmann/json.hpp>
+
+//! Project Headers
+#include "atomicdex/api/mm2/rpc.balance.hpp"
+#include "atomicdex/utilities/global.utilities.hpp"
+
+namespace mm2::api
+{
+    void
+    to_json(nlohmann::json& j, const balance_request& cfg)
+    {
+        j["coin"] = cfg.coin;
+    }
+
+    void
+    from_json(const nlohmann::json& j, balance_answer& cfg)
+    {
+        j.at("address").get_to(cfg.address);
+        j.at("balance").get_to(cfg.balance);
+        cfg.balance = atomic_dex::utils::adjust_precision(cfg.balance);
+        j.at("coin").get_to(cfg.coin);
+        if (cfg.coin == "BCH")
+        {
+            cfg.address = cfg.address.substr(sizeof("bitcoincash"));
+        }
+    }
+} // namespace mm2::api

--- a/src/atomicdex/api/mm2/rpc.balance.hpp
+++ b/src/atomicdex/api/mm2/rpc.balance.hpp
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright © 2013-2021 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+namespace mm2::api
+{
+    struct balance_request
+    {
+        std::string coin;
+    };
+
+    struct balance_answer
+    {
+        std::string address;
+        std::string balance;
+        std::string coin;
+        int         rpc_result_code;
+        std::string raw_result;
+    };
+
+    void to_json(nlohmann::json& j, const balance_request& cfg);
+
+    void from_json(const nlohmann::json& j, balance_answer& cfg);
+} // namespace mm2::api
+
+namespace atomic_dex
+{
+    using t_balance_request = ::mm2::api::balance_request;
+    using t_balance_answer  = ::mm2::api::balance_answer;
+} // namespace atomic_dex

--- a/src/atomicdex/api/mm2/rpc.electrum.cpp
+++ b/src/atomicdex/api/mm2/rpc.electrum.cpp
@@ -1,0 +1,47 @@
+/******************************************************************************
+ * Copyright © 2013-2021 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+//! Deps
+#include <nlohmann/json.hpp>
+
+//! Project Deps
+#include "atomicdex/api/mm2/rpc.electrum.hpp"
+
+//! Implementation RPC [electrum]
+namespace mm2::api
+{
+    //! Serialization
+    void
+    to_json(nlohmann::json& j, const electrum_request& cfg)
+    {
+        j["coin"]       = cfg.coin_name;
+        j["servers"]    = cfg.servers;
+        j["tx_history"] = cfg.with_tx_history;
+        if (cfg.coin_type == CoinType::QRC20)
+        {
+            j["swap_contract_address"] = cfg.is_testnet ? cfg.testnet_qrc_swap_contract_address : cfg.mainnet_qrc_swap_contract_address;
+        }
+    }
+
+    //! Deserialization
+    void
+    from_json(const nlohmann::json& j, electrum_answer& cfg)
+    {
+        j.at("address").get_to(cfg.address);
+        j.at("balance").get_to(cfg.balance);
+        j.at("result").get_to(cfg.result);
+    }
+} // namespace mm2::api

--- a/src/atomicdex/api/mm2/rpc.electrum.hpp
+++ b/src/atomicdex/api/mm2/rpc.electrum.hpp
@@ -1,0 +1,57 @@
+/******************************************************************************
+ * Copyright © 2013-2021 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+#pragma once
+
+//! Deps
+#include <nlohmann/json_fwd.hpp>
+
+//! Project Headers
+#include "atomicdex/config/electrum.cfg.hpp"
+#include "atomicdex/constants/qt.coins.enums.hpp"
+
+namespace mm2::api
+{
+    struct electrum_request
+    {
+        std::string                              coin_name;
+        std::vector<atomic_dex::electrum_server> servers;
+        CoinType                                 coin_type;
+        bool                                     is_testnet{false};
+        bool                                     with_tx_history{true};
+        const std::string                        testnet_qrc_swap_contract_address{"0xba8b71f3544b93e2f681f996da519a98ace0107a"};
+        const std::string                        mainnet_qrc_swap_contract_address{"0x2f754733acd6d753731c00fee32cb484551cc15d"};
+    };
+
+    struct electrum_answer
+    {
+        std::string address;
+        std::string balance;
+        std::string result;
+        int         rpc_result_code;
+        std::string raw_result;
+    };
+
+    void to_json(nlohmann::json& j, const electrum_request& cfg);
+
+    void from_json(const nlohmann::json& j, electrum_answer& answer);
+} // namespace mm2::api
+
+namespace atomic_dex
+{
+    using t_electrum_request = ::mm2::api::electrum_request;
+    using t_electrum_answer  = ::mm2::api::electrum_answer;
+} // namespace atomic_dex

--- a/src/atomicdex/api/mm2/rpc.enable.cpp
+++ b/src/atomicdex/api/mm2/rpc.enable.cpp
@@ -1,0 +1,48 @@
+/******************************************************************************
+ * Copyright © 2013-2021 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+//! Deps
+#include <nlohmann/json.hpp>
+
+//! Project Headers
+#include "atomicdex/api/mm2/rpc.enable.hpp"
+
+//! Implementation RPC [enable]
+namespace mm2::api
+{
+    //! Serialization
+    void
+    to_json(nlohmann::json& j, const enable_request& cfg)
+    {
+        j["coin"] = cfg.coin_name;
+        if (cfg.coin_type == CoinType::ERC20)
+        {
+            j["gas_station_url"]       = cfg.gas_station_url;
+            j["swap_contract_address"] = cfg.erc_swap_contract_address;
+            j["urls"]                  = cfg.urls;
+        }
+        j["tx_history"] = cfg.with_tx_history;
+    }
+
+    //! Deserialization
+    void
+    from_json(const nlohmann::json& j, enable_answer& cfg)
+    {
+        j.at("address").get_to(cfg.address);
+        j.at("balance").get_to(cfg.balance);
+        j.at("result").get_to(cfg.result);
+    }
+} // namespace mm2::api

--- a/src/atomicdex/api/mm2/rpc.enable.hpp
+++ b/src/atomicdex/api/mm2/rpc.enable.hpp
@@ -1,0 +1,57 @@
+/******************************************************************************
+ * Copyright © 2013-2021 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+#pragma once
+
+//! Deps
+#include <nlohmann/json_fwd.hpp>
+
+//! Project Headers
+#include "atomicdex/constants/qt.coins.enums.hpp"
+
+namespace mm2::api
+{
+    //! Only for erc 20
+    struct enable_request
+    {
+        std::string              coin_name;
+        std::vector<std::string> urls;
+        CoinType                 coin_type;
+        const std::string        erc_swap_contract_address{"0x8500AFc0bc5214728082163326C2FF0C73f4a871"};
+        std::string              gas_station_url{"https://ethgasstation.info/json/ethgasAPI.json"};
+        std::string              type; ///< QRC-20 ?
+        bool                     with_tx_history{true};
+    };
+
+    void to_json(nlohmann::json& j, const enable_request& cfg);
+
+    struct enable_answer
+    {
+        std::string address;
+        std::string balance;
+        std::string result;
+        std::string raw_result;
+        int         rpc_result_code;
+    };
+
+    void from_json(const nlohmann::json& j, const enable_answer& cfg);
+} // namespace mm2::api
+
+namespace atomic_dex
+{
+    using t_enable_request = ::mm2::api::enable_request;
+    using t_enable_answer  = ::mm2::api::enable_answer;
+} // namespace atomic_dex

--- a/src/atomicdex/config/coins.cfg.cpp
+++ b/src/atomicdex/config/coins.cfg.cpp
@@ -23,34 +23,6 @@
 namespace atomic_dex
 {
     void
-    to_json(nlohmann::json& j, const electrum_server& cfg)
-    {
-        j["url"] = cfg.url;
-        if (cfg.protocol.has_value())
-        {
-            j["protocol"] = cfg.protocol.value();
-        }
-        if (cfg.disable_cert_verification.has_value())
-        {
-            j["disable_cert_verification"] = cfg.disable_cert_verification.value();
-        }
-    }
-
-    void
-    from_json(const nlohmann::json& j, electrum_server& cfg)
-    {
-        if (j.count("protocol") == 1)
-        {
-            cfg.protocol = j.at("protocol").get<std::string>();
-        }
-        if (j.count("disable_cert_verification") == 1)
-        {
-            cfg.disable_cert_verification = j.at("disable_cert_verification").get<bool>();
-        }
-        j.at("url").get_to(cfg.url);
-    }
-
-    void
     from_json(const nlohmann::json& j, coin_config& cfg)
     {
         j.at("coin").get_to(cfg.ticker);

--- a/src/atomicdex/config/coins.cfg.hpp
+++ b/src/atomicdex/config/coins.cfg.hpp
@@ -26,21 +26,12 @@
 #include <nlohmann/json.hpp>
 
 //! Project
+#include "atomicdex/config/electrum.cfg.hpp"
 #include "atomicdex/constants/mm2.constants.hpp"
 #include "atomicdex/constants/qt.coins.enums.hpp"
 
 namespace atomic_dex
 {
-    struct electrum_server
-    {
-        std::string                url;
-        std::optional<std::string> protocol{"TCP"};
-        std::optional<bool>        disable_cert_verification{false};
-    };
-
-    void to_json(nlohmann::json& j, const electrum_server& cfg);
-    void from_json(const nlohmann::json& j, electrum_server& cfg);
-
     struct coin_config
     {
       public:
@@ -64,9 +55,9 @@ namespace atomic_dex
         std::string                     tx_uri{"tx/"};
         std::string                     address_url{"address/"};
         std::optional<nlohmann::json>   custom_backup;
-        std::optional<bool> is_testnet{false}; ///< True if testnet (tBTC, tQTUM, QRC-20 on testnet, tETH)
-        CoinType            coin_type;
-        bool                checked{false};
+        std::optional<bool>             is_testnet{false}; ///< True if testnet (tBTC, tQTUM, QRC-20 on testnet, tETH)
+        CoinType                        coin_type;
+        bool                            checked{false};
     };
 
     void from_json(const nlohmann::json& j, coin_config& cfg);

--- a/src/atomicdex/config/electrum.cfg.cpp
+++ b/src/atomicdex/config/electrum.cfg.cpp
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright © 2013-2021 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+
+//! Deps
+#include <nlohmann/json.hpp>
+
+//! Project Headers
+#include "atomicdex/config/electrum.cfg.hpp"
+
+namespace atomic_dex
+{
+    void
+    to_json(nlohmann::json& j, const electrum_server& cfg)
+    {
+        j["url"] = cfg.url;
+        if (cfg.protocol.has_value())
+        {
+            j["protocol"] = cfg.protocol.value();
+        }
+        if (cfg.disable_cert_verification.has_value())
+        {
+            j["disable_cert_verification"] = cfg.disable_cert_verification.value();
+        }
+    }
+
+    void
+    from_json(const nlohmann::json& j, electrum_server& cfg)
+    {
+        if (j.count("protocol") == 1)
+        {
+            cfg.protocol = j.at("protocol").get<std::string>();
+        }
+        if (j.count("disable_cert_verification") == 1)
+        {
+            cfg.disable_cert_verification = j.at("disable_cert_verification").get<bool>();
+        }
+        j.at("url").get_to(cfg.url);
+    }
+} // namespace atomic_dex

--- a/src/atomicdex/config/electrum.cfg.hpp
+++ b/src/atomicdex/config/electrum.cfg.hpp
@@ -17,6 +17,10 @@
 
 #pragma once
 
+//! STD
+#include <optional>
+#include <string>
+
 namespace atomic_dex
 {
     struct electrum_server

--- a/src/atomicdex/config/electrum.cfg.hpp
+++ b/src/atomicdex/config/electrum.cfg.hpp
@@ -1,0 +1,31 @@
+/******************************************************************************
+ * Copyright © 2013-2021 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+
+#pragma once
+
+namespace atomic_dex
+{
+    struct electrum_server
+    {
+        std::string                url;
+        std::optional<std::string> protocol{"TCP"};
+        std::optional<bool>        disable_cert_verification{false};
+    };
+
+    void to_json(nlohmann::json& j, const electrum_server& cfg);
+    void from_json(const nlohmann::json& j, electrum_server& cfg);
+}

--- a/src/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/atomicdex/services/mm2/mm2.service.cpp
@@ -23,6 +23,7 @@
 #include "atomicdex/config/mm2.cfg.hpp"
 #include "atomicdex/managers/qt.wallet.manager.hpp"
 #include "atomicdex/services/mm2/mm2.service.hpp"
+#include "atomicdex/utilities/kill.hpp" ///< no delete
 #include "atomicdex/utilities/stacktrace.prerequisites.hpp"
 
 //! Anonymous functions

--- a/src/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/atomicdex/services/mm2/mm2.service.cpp
@@ -17,19 +17,12 @@
 //! STD
 #include <unordered_set>
 
-#if defined(linux) || defined(__APPLE__)
-#    define BOOST_STACKTRACE_USE_ADDR2LINE
-#    if defined(__APPLE__)
-#        define _GNU_SOURCE
-#    endif
-#    include <boost/stacktrace.hpp>
-#endif
-
 //! Project Headers
+#include "atomicdex/api/mm2/rpc.enable.hpp"
 #include "atomicdex/config/mm2.cfg.hpp"
 #include "atomicdex/managers/qt.wallet.manager.hpp"
 #include "atomicdex/services/mm2/mm2.service.hpp"
-#include "atomicdex/utilities/kill.hpp"
+#include "atomicdex/utilities/stacktrace.prerequisites.hpp"
 
 //! Anonymous functions
 namespace
@@ -40,7 +33,7 @@ namespace
     check_for_reconfiguration(const std::string& wallet_name)
     {
         using namespace std::string_literals;
-        SPDLOG_DEBUG("{} l{} f[{}]", __FUNCTION__, __LINE__, fs::path(__FILE__).filename().string());
+        SPDLOG_DEBUG("checking for reconfiguration");
 
         fs::path    cfg_path                   = atomic_dex::utils::get_atomic_dex_config_folder();
         std::string filename                   = std::string(atomic_dex::get_precedent_raw_version()) + "-coins." + wallet_name + ".json";
@@ -683,7 +676,7 @@ namespace atomic_dex
 
         //! Prepare fees
         auto batch = prepare_process_fees_and_current_orderbook();
-        //SPDLOG_INFO("Request: {}", batch.dump(4));
+        // SPDLOG_INFO("Request: {}", batch.dump(4));
         if (batch.empty())
         {
             return;
@@ -694,7 +687,7 @@ namespace atomic_dex
             .then(
                 [this, orderbook_ticker_base = orderbook_ticker_base, orderbook_ticker_rel = orderbook_ticker_rel, is_a_reset](web::http::http_response resp) {
                     auto answer = ::mm2::api::basic_batch_answer(resp);
-                    //SPDLOG_INFO("Debug output: {}", answer.dump(4));
+                    // SPDLOG_INFO("Debug output: {}", answer.dump(4));
                     if (answer.is_array())
                     {
                         auto trade_fee_base_answer = ::mm2::api::rpc_process_answer_batch<t_get_trade_fee_answer>(answer[0], "get_trade_fee");

--- a/src/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/atomicdex/services/mm2/mm2.service.cpp
@@ -18,6 +18,7 @@
 #include <unordered_set>
 
 //! Project Headers
+#include "atomicdex/api/mm2/rpc.electrum.hpp"
 #include "atomicdex/api/mm2/rpc.enable.hpp"
 #include "atomicdex/config/mm2.cfg.hpp"
 #include "atomicdex/managers/qt.wallet.manager.hpp"

--- a/src/atomicdex/services/mm2/mm2.service.hpp
+++ b/src/atomicdex/services/mm2/mm2.service.hpp
@@ -28,6 +28,7 @@
 
 //! Project Headers
 #include "atomicdex/api/mm2/mm2.hpp"
+#include "atomicdex/api/mm2/rpc.balance.hpp"
 #include "atomicdex/api/mm2/rpc.max.taker.vol.hpp"
 #include "atomicdex/config/coins.cfg.hpp"
 #include "atomicdex/config/raw.mm2.coins.cfg.hpp"

--- a/src/atomicdex/utilities/stacktrace.prerequisites.hpp
+++ b/src/atomicdex/utilities/stacktrace.prerequisites.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+//! Stacktrace
+#if defined(linux) || defined(__APPLE__)
+#    define BOOST_STACKTRACE_USE_ADDR2LINE
+#    if defined(__APPLE__)
+#        define _GNU_SOURCE
+#    endif
+#    include <boost/stacktrace.hpp>
+#endif


### PR DESCRIPTION
- Add stacktrace.prerequisites.hpp to simplify stacktrace inclusion
- Add rpc.enable.cpp/.hpp that represents the mm2 enable rpc call
- Remove enable rpc from mm2.cpp/.hpp
- Add the sources to the CMakeLists.txt