### PR TITLE
feat(auto_update): start auto update maker order service

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,26 +1,26 @@
 include(DEX_NEW_LIB)
 
 # Core target
-DEX_NEW_LIB(core STATIC
-        PUBLIC_DEPS
+DEX_NEW_LIB(core INTERFACE
+        INTERFACE_DEPS
             cpprestsdk::cpprest Qt::Core Qt::Quick Qt::Svg Qt::Charts Qt::WebEngine Qt::WebEngineCore Qt::WebEngineWidgets
             Qt::Widgets nlohmann_json::nlohmann_json antara_qrcode spdlog::spdlog antara::world reproc++
             unofficial-btc::bitcoin komodo-date::date komodo-taskflow::taskflow
             Boost::random Boost::filesystem komodo-sodium::sodium antara::app::net
-        PUBLIC_DEFS
+        INTERFACE_DEFS
             $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG> $<$<PLATFORM_ID:Windows>:HAS_REMOTE_API>
             $<$<PLATFORM_ID:Windows>:AUTO_DOWNLOAD> DEX_NAME="${DEX_DISPLAY_NAME}" DEX_WEBSITE_URL="${DEX_WEBSITE}"
             DEX_SUPPORT_URL="${DEX_SUPPORT_PAGE}" DEX_DISCORD_URL="${DEX_DISCORD}" DEX_TWITTER_URL="${DEX_TWITTER}"
             DEX_PRIMARY_COIN="${DEX_PRIMARY_COIN}" DEX_SECOND_PRIMARY_COIN="${DEX_SECOND_PRIMARY_COIN}" #DEX_COMMON_DATA_FOLDER="${DEX_COMMON_DATA_FOLDER}"
-        PRIVATE_DEFS
+        INTERFACE_DEFS
             ENTT_API_EXPORT)
-target_precompile_headers(${PROJECT_NAME}_core PUBLIC core/atomicdex/pch.hpp)
+target_precompile_headers(${PROJECT_NAME}_core INTERFACE core/atomicdex/pch.hpp)
 if (APPLE)
     set_source_files_properties(core/atomicdex/platform/osx/manager.mm PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
 endif ()
 if (DISABLE_GEOBLOCKING)
     message(STATUS "Disabling Geoblocking for dev purpose")
-    target_compile_definitions(${PROJECT_NAME}_core PUBLIC -DDISABLE_GEOBLOCKING)
+    target_compile_definitions(${PROJECT_NAME}_core INTERFACE -DDISABLE_GEOBLOCKING)
 endif ()
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,17 +3,17 @@ include(DEX_NEW_LIB)
 # Core target
 DEX_NEW_LIB(core INTERFACE
         INTERFACE_DEPS
-            cpprestsdk::cpprest Qt::Core Qt::Quick Qt::Svg Qt::Charts Qt::WebEngine Qt::WebEngineCore Qt::WebEngineWidgets
-            Qt::Widgets nlohmann_json::nlohmann_json antara_qrcode spdlog::spdlog antara::world reproc++
-            unofficial-btc::bitcoin komodo-date::date komodo-taskflow::taskflow
-            Boost::random Boost::filesystem komodo-sodium::sodium antara::app::net
+        cpprestsdk::cpprest Qt::Core Qt::Quick Qt::Svg Qt::Charts Qt::WebEngine Qt::WebEngineCore Qt::WebEngineWidgets
+        Qt::Widgets nlohmann_json::nlohmann_json antara_qrcode spdlog::spdlog antara::world reproc++
+        unofficial-btc::bitcoin komodo-date::date komodo-taskflow::taskflow
+        Boost::random Boost::filesystem komodo-sodium::sodium antara::app::net
         INTERFACE_DEFS
-            $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG> $<$<PLATFORM_ID:Windows>:HAS_REMOTE_API>
-            $<$<PLATFORM_ID:Windows>:AUTO_DOWNLOAD> DEX_NAME="${DEX_DISPLAY_NAME}" DEX_WEBSITE_URL="${DEX_WEBSITE}"
-            DEX_SUPPORT_URL="${DEX_SUPPORT_PAGE}" DEX_DISCORD_URL="${DEX_DISCORD}" DEX_TWITTER_URL="${DEX_TWITTER}"
-            DEX_PRIMARY_COIN="${DEX_PRIMARY_COIN}" DEX_SECOND_PRIMARY_COIN="${DEX_SECOND_PRIMARY_COIN}" #DEX_COMMON_DATA_FOLDER="${DEX_COMMON_DATA_FOLDER}"
+        $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG> $<$<PLATFORM_ID:Windows>:HAS_REMOTE_API>
+        $<$<PLATFORM_ID:Windows>:AUTO_DOWNLOAD> DEX_NAME="${DEX_DISPLAY_NAME}" DEX_WEBSITE_URL="${DEX_WEBSITE}"
+        DEX_SUPPORT_URL="${DEX_SUPPORT_PAGE}" DEX_DISCORD_URL="${DEX_DISCORD}" DEX_TWITTER_URL="${DEX_TWITTER}"
+        DEX_PRIMARY_COIN="${DEX_PRIMARY_COIN}" DEX_SECOND_PRIMARY_COIN="${DEX_SECOND_PRIMARY_COIN}" #DEX_COMMON_DATA_FOLDER="${DEX_COMMON_DATA_FOLDER}"
         INTERFACE_DEFS
-            ENTT_API_EXPORT)
+        ENTT_API_EXPORT)
 target_precompile_headers(${PROJECT_NAME}_core INTERFACE core/atomicdex/pch.hpp)
 if (APPLE)
     set_source_files_properties(core/atomicdex/platform/osx/manager.mm PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
@@ -60,6 +60,11 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE ENTT_API_IMPORT)
 set_target_properties(${PROJECT_NAME}
         PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/")
+
+set_target_properties(${PROJECT_NAME} PROPERTIES UNITY_BUILD ON)
+if (APPLE)
+    set_property(SOURCE core/atomicdex/platform/osx/manager.mm PROPERTY SKIP_UNITY_BUILD_INCLUSION ON)
+endif ()
 
 # Testing executable
 add_executable(${PROJECT_NAME}_tests MACOSX_BUNDLE ${ICON}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,6 +97,7 @@ target_link_libraries(${PROJECT_NAME}_tests
 set_target_properties(${PROJECT_NAME}_tests
         PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/")
+set_target_properties(${PROJECT_NAME}_tests PROPERTIES UNITY_BUILD ON)
 
 # Main executable installation related
 if (LINUX)

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -37,6 +37,7 @@
 //! Project Headers
 #include "app.hpp"
 #include "atomicdex/services/exporter/exporter.service.hpp"
+#include "atomicdex/services/mm2/auto.update.maker.order.service.hpp"
 #include "atomicdex/services/price/coingecko/coingecko.provider.hpp"
 #include "atomicdex/services/price/coinpaprika/coinpaprika.provider.hpp"
 #include "atomicdex/services/price/oracle/band.provider.hpp"
@@ -233,30 +234,45 @@ namespace atomic_dex
     }
 
     mm2_service&
-    application::get_mm2() 
+    application::get_mm2()
     {
         return this->system_manager_.get_system<mm2_service>();
     }
 
     entt::dispatcher&
-    application::get_dispatcher() 
+    application::get_dispatcher()
     {
         return this->dispatcher_;
     }
 
     const entt::registry&
-    application::get_registry() const 
+    application::get_registry() const
     {
         return this->entity_registry_;
     }
 
     entt::registry&
-    application::get_registry() 
+    application::get_registry()
     {
         return this->entity_registry_;
     }
 
-    application::application(QObject* pParent)  : QObject(pParent)
+    void
+    application::post_handle_settings()
+    {
+        QSettings& settings = get_registry().ctx<QSettings>();
+        if (settings.value("AutomaticUpdateOrderBot", false).toBool())
+        {
+            SPDLOG_INFO("AutomaticUpdateOrderBot is true, activating the service");
+            system_manager_.create_system<auto_update_maker_order_service>(system_manager_);
+        }
+        else
+        {
+            SPDLOG_WARN("AutomaticUpdateOrderBot is false, ignoring the service");
+        }
+    }
+
+    application::application(QObject* pParent) : QObject(pParent)
     {
         fs::path settings_path = (atomic_dex::utils::get_current_configs_path() / "cfg.ini");
         this->entity_registry_.set<QSettings>(settings_path.string().c_str(), QSettings::IniFormat);
@@ -304,7 +320,7 @@ namespace atomic_dex
     }
 
     void
-    application::on_coin_fully_initialized_event(const coin_fully_initialized& evt) 
+    application::on_coin_fully_initialized_event(const coin_fully_initialized& evt)
     {
         //! This event is called when a call is enabled and cex provider finished fetch data
         if (not m_event_actions[events_action::about_to_exit_app])
@@ -326,7 +342,7 @@ namespace atomic_dex
     }
 
     const mm2_service&
-    application::get_mm2() const 
+    application::get_mm2() const
     {
         return this->system_manager_.get_system<mm2_service>();
     }
@@ -340,7 +356,7 @@ namespace atomic_dex
     }
 
     void
-    application::on_mm2_initialized_event([[maybe_unused]] const mm2_initialized& evt) 
+    application::on_mm2_initialized_event([[maybe_unused]] const mm2_initialized& evt)
     {
         SPDLOG_DEBUG("{} l{}", __FUNCTION__, __LINE__);
         system_manager_.get_system<qt_wallet_manager>().set_status("enabling_coins");
@@ -412,7 +428,7 @@ namespace atomic_dex
         wallet_manager.just_set_wallet_name("");
 
         this->m_secondary_coin_fully_enabled = false;
-        this->m_primary_coin_fully_enabled = false;
+        this->m_primary_coin_fully_enabled   = false;
         system_manager_.get_system<qt_wallet_manager>().set_status("None");
         return fs::remove(utils::get_atomic_dex_config_folder() / "default.wallet");
     }
@@ -433,7 +449,7 @@ namespace atomic_dex
     }
 
     void
-    application::set_qt_app(std::shared_ptr<QApplication> app, QQmlApplicationEngine* engine) 
+    application::set_qt_app(std::shared_ptr<QApplication> app, QQmlApplicationEngine* engine)
     {
         this->m_app = app;
         connect(m_app.get(), SIGNAL(aboutToQuit()), this, SLOT(exit_handler()));
@@ -485,7 +501,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     void
-    application::on_fiat_rate_updated(const fiat_rate_updated&) 
+    application::on_fiat_rate_updated(const fiat_rate_updated&)
     {
         SPDLOG_DEBUG("on_fiat_rate_updated");
         this->dispatcher_.trigger<update_portfolio_values>();
@@ -493,7 +509,7 @@ namespace atomic_dex
     }
 
     void
-    application::on_ticker_balance_updated_event(const ticker_balance_updated& evt) 
+    application::on_ticker_balance_updated_event(const ticker_balance_updated& evt)
     {
         SPDLOG_DEBUG("{} l{}", __FUNCTION__, __LINE__);
         if (not m_event_actions[events_action::about_to_exit_app])
@@ -511,7 +527,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     /*void
-    application::on_process_swaps_finished_event([[maybe_unused]] const process_swaps_finished& evt) 
+    application::on_process_swaps_finished_event([[maybe_unused]] const process_swaps_finished& evt)
     {
         if (not m_event_actions[events_action::about_to_exit_app])
         {
@@ -520,7 +536,7 @@ namespace atomic_dex
     }*/
 
     void
-    application::on_process_orders_and_swaps_finished_event([[maybe_unused]] const process_swaps_and_orders_finished& evt) 
+    application::on_process_orders_and_swaps_finished_event([[maybe_unused]] const process_swaps_and_orders_finished& evt)
     {
         if (not m_event_actions[events_action::about_to_exit_app])
         {
@@ -530,7 +546,7 @@ namespace atomic_dex
     }
 
     orders_model*
-    application::get_orders() const 
+    application::get_orders() const
     {
         return qobject_cast<orders_model*>(m_manager_models.at("orders"));
     }
@@ -540,7 +556,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     portfolio_page*
-    application::get_portfolio_page() const 
+    application::get_portfolio_page() const
     {
         portfolio_page* ptr = const_cast<portfolio_page*>(std::addressof(system_manager_.get_system<portfolio_page>()));
         assert(ptr != nullptr);
@@ -552,7 +568,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     bool
-    application::is_pin_cfg_enabled() const 
+    application::is_pin_cfg_enabled() const
     {
         return get_mm2().is_pin_cfg_enabled();
     }
@@ -596,7 +612,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     trading_page*
-    application::get_trading_page() const 
+    application::get_trading_page() const
     {
         trading_page* ptr = const_cast<trading_page*>(std::addressof(system_manager_.get_system<trading_page>()));
         assert(ptr != nullptr);
@@ -608,7 +624,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     wallet_page*
-    application::get_wallet_page() const 
+    application::get_wallet_page() const
     {
         auto ptr = const_cast<wallet_page*>(std::addressof(system_manager_.get_system<wallet_page>()));
         assert(ptr != nullptr);
@@ -620,7 +636,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     settings_page*
-    application::get_settings_page() const 
+    application::get_settings_page() const
     {
         auto ptr = const_cast<settings_page*>(std::addressof(system_manager_.get_system<settings_page>()));
         assert(ptr != nullptr);
@@ -632,7 +648,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     addressbook_page*
-    application::get_addressbook_page() const 
+    application::get_addressbook_page() const
     {
         auto ptr = const_cast<addressbook_page*>(std::addressof(system_manager_.get_system<addressbook_page>()));
         assert(ptr != nullptr);
@@ -644,7 +660,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     notification_manager*
-    application::get_notification_manager() const 
+    application::get_notification_manager() const
     {
         return qobject_cast<notification_manager*>(m_manager_models.at("notifications"));
     }
@@ -654,7 +670,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     internet_service_checker*
-    application::get_internet_checker() const 
+    application::get_internet_checker() const
     {
         return qobject_cast<internet_service_checker*>(m_manager_models.at("internet_service"));
     }
@@ -664,7 +680,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     update_service_checker*
-    application::get_update_checker() const 
+    application::get_update_checker() const
     {
         auto ptr = const_cast<update_service_checker*>(std::addressof(system_manager_.get_system<update_service_checker>()));
         assert(ptr != nullptr);
@@ -676,7 +692,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     ip_service_checker*
-    application::get_ip_checker() const 
+    application::get_ip_checker() const
     {
         auto ptr = const_cast<ip_service_checker*>(std::addressof(system_manager_.get_system<ip_service_checker>()));
         assert(ptr != nullptr);
@@ -688,7 +704,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     exporter_service*
-    application::get_exporter_service() const 
+    application::get_exporter_service() const
     {
         auto ptr = const_cast<exporter_service*>(std::addressof(system_manager_.get_system<exporter_service>()));
         assert(ptr != nullptr);
@@ -700,7 +716,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     qt_wallet_manager*
-    application::get_wallet_mgr() const 
+    application::get_wallet_mgr() const
     {
         auto ptr = const_cast<qt_wallet_manager*>(std::addressof(system_manager_.get_system<qt_wallet_manager>()));
         assert(ptr != nullptr);
@@ -725,7 +741,17 @@ namespace atomic_dex
 
         if (appimage == nullptr || not QString(appimage).contains("atomicdex-desktop"))
         {
-            QProcess::startDetached(qApp->arguments()[0], qApp->arguments(), qApp->applicationDirPath());
+            // qDebug() << qApp->arguments();
+            // SPDLOG_INFO("arg: {}, dir path: {}", qApp->arguments()[0].toStdString(), qApp->applicationDirPath().toStdString());
+            bool res = QProcess::startDetached(qApp->arguments()[0], qApp->arguments(), qApp->applicationDirPath());
+            if (!res)
+            {
+                SPDLOG_ERROR("Couldn't start a new process");
+            }
+            else
+            {
+                SPDLOG_INFO("Successfully restarted the app");
+            }
         }
         else
         {

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -465,7 +465,7 @@ namespace atomic_dex
         QString result;
 
         ::mm2::api::recover_funds_of_swap_request request{.swap_uuid = uuid.toStdString()};
-        auto                                      res = ::mm2::api::rpc_recover_funds(std::move(request), get_mm2().get_mm2_client());
+        auto                                      res = get_mm2().get_mm2_client().rpc_recover_funds(std::move(request));
         result                                        = QString::fromStdString(res.raw_result);
 
         return result;

--- a/src/app/app.hpp
+++ b/src/app/app.hpp
@@ -112,6 +112,9 @@ namespace atomic_dex
         explicit application(QObject* pParent = nullptr) ;
         ~application()  final = default;
 
+        //! Post constructor
+        void post_handle_settings();
+
         //! entt::dispatcher events
         void on_ticker_balance_updated_event(const ticker_balance_updated&) ;
         void on_fiat_rate_updated(const fiat_rate_updated&) ;

--- a/src/app/main.prerequisites.hpp
+++ b/src/app/main.prerequisites.hpp
@@ -332,14 +332,18 @@ handle_settings(QSettings& settings)
     create_settings_functor("CurrentTheme", QString("Dark.json"));
     create_settings_functor("ThemePath", QString::fromStdString(atomic_dex::utils::get_themes_path().string()));
     create_settings_functor("SecondSecuritySending", QVariant(false));
+    create_settings_functor("AutomaticUpdateOrderBot", QVariant(false));
 #ifdef __APPLE__
     create_settings_functor("FontMode", QQuickWindow::TextRenderType::NativeTextRendering);
     QQuickWindow::setTextRenderType(static_cast<QQuickWindow::TextRenderType>(settings.value("FontMode").toInt()));
 #else
     create_settings_functor("FontMode", QQuickWindow::TextRenderType::QtTextRendering);
 #endif
-    /*settings.beginGroup("BestOrders");
-    create_settings_functor("show_affordable_offers", QVariant(true));
+    /*settings.beginGroup("KMD_BUSD-BEP20");
+    create_settings_functor("Bidspread", QVariant(-1.0));
+    create_settings_functor("Askspread", QVariant(1.0));
+    create_settings_functor("Disabled", QVariant(true));
+    create_settings_functor("AutoCancel", QVariant(true));
     settings.endGroup();*/
 }
 
@@ -366,6 +370,7 @@ run_app(int argc, char** argv)
     atomic_dex::application atomic_app;
     QSettings&              settings = atomic_app.get_registry().ctx<QSettings>();
     handle_settings(settings);
+    atomic_app.post_handle_settings();
 
     int res = 0;
 

--- a/src/app/main.prerequisites.hpp
+++ b/src/app/main.prerequisites.hpp
@@ -339,11 +339,15 @@ handle_settings(QSettings& settings)
 #else
     create_settings_functor("FontMode", QQuickWindow::TextRenderType::QtTextRendering);
 #endif
+
     /*settings.beginGroup("KMD_BUSD-BEP20");
-    create_settings_functor("Bidspread", QVariant(-1.0));
-    create_settings_functor("Askspread", QVariant(1.0));
-    create_settings_functor("Disabled", QVariant(true));
-    create_settings_functor("AutoCancel", QVariant(true));
+    create_settings_functor("Spread", QVariant(2.0));
+    create_settings_functor("Disabled", QVariant(false));
+    settings.endGroup();
+
+    settings.beginGroup("BUSD-BEP20_KMD");
+    create_settings_functor("Spread", QVariant(2.0));
+    create_settings_functor("Disabled", QVariant(false));
     settings.endGroup();*/
 }
 

--- a/src/core/atomicdex/api/coinpaprika/coinpaprika.cpp
+++ b/src/core/atomicdex/api/coinpaprika/coinpaprika.cpp
@@ -47,8 +47,8 @@ namespace atomic_dex
         void
         from_json(const nlohmann::json& j, price_converter_answer& evt)
         {
-            utils::details::my_json_sax sx;
-            nlohmann::json::sax_parse(j.dump(), &sx);
+            // utils::details::my_json_sax sx;
+            // nlohmann::json::sax_parse(j.dump(), &sx);
 
             evt.base_currency_id         = j.at("base_currency_id").get<std::string>();
             evt.base_currency_name       = j.at("base_currency_name").get<std::string>();
@@ -57,7 +57,7 @@ namespace atomic_dex
             evt.quote_currency_name      = j.at("quote_currency_name").get<std::string>();
             evt.quote_price_last_updated = j.at("quote_price_last_updated").get<std::string>();
             evt.amount                   = j.at("amount").get<int64_t>();
-            evt.price                    = sx.float_as_string;
+            evt.price                    = std::to_string(j.at("price").get<double>());
 
             std::replace(evt.price.begin(), evt.price.end(), ',', '.');
         }

--- a/src/core/atomicdex/api/mm2/generics.cpp
+++ b/src/core/atomicdex/api/mm2/generics.cpp
@@ -21,6 +21,7 @@
 #include "atomicdex/api/mm2/generics.hpp"
 #include "atomicdex/api/mm2/rpc.best.orders.hpp"
 #include "atomicdex/api/mm2/rpc.buy.hpp"
+#include "atomicdex/api/mm2/rpc.disable.hpp"
 #include "atomicdex/api/mm2/rpc.max.taker.vol.hpp"
 #include "atomicdex/api/mm2/rpc.sell.hpp"
 #include "atomicdex/api/mm2/rpc.trade.preimage.hpp"
@@ -46,4 +47,5 @@ namespace mm2::api
     template void extract_rpc_json_answer<buy_answer_success>(const nlohmann::json& j, buy_answer& answer);
     template void extract_rpc_json_answer<sell_answer_success>(const nlohmann::json& j, sell_answer& answer);
     template void extract_rpc_json_answer<best_orders_answer_success>(const nlohmann::json& j, best_orders_answer& answer);
+    template void extract_rpc_json_answer<disable_coin_answer_success>(const nlohmann::json& j, disable_coin_answer& answer);
 } // namespace mm2::api

--- a/src/core/atomicdex/api/mm2/mm2.client.cpp
+++ b/src/core/atomicdex/api/mm2/mm2.client.cpp
@@ -1,0 +1,135 @@
+//
+// Created by Sztergbaum Roman on 27/03/2021.
+//
+
+//! Deps
+#include <meta/detection/detection.hpp>
+
+//! Project Headers
+#include "atomicdex/api/mm2/mm2.client.hpp"
+#include "atomicdex/api/mm2/mm2.hpp"
+
+namespace
+{
+    template <typename T>
+    using have_error_field = decltype(std::declval<T&>().error.has_value());
+
+    t_http_client
+    generate_client()
+    {
+        web::http::client::http_client_config cfg;
+        using namespace std::chrono_literals;
+        cfg.set_timeout(30s);
+        return web::http::client::http_client(FROM_STD_STR(::mm2::api::g_endpoint), cfg);
+    }
+} // namespace
+
+namespace atomic_dex
+{
+    template <typename RpcReturnType>
+    RpcReturnType
+    mm2_client::rpc_process_answer(const web::http::http_response& resp, const std::string& rpc_command)
+    {
+        std::string body = TO_STD_STR(resp.extract_string(true).get());
+        SPDLOG_INFO("resp code for rpc_command {} is {}", rpc_command, resp.status_code());
+        RpcReturnType answer;
+
+        try
+        {
+            if (resp.status_code() not_eq 200)
+            {
+                SPDLOG_WARN("rpc answer code is not 200, body : {}", body);
+                if constexpr (doom::meta::is_detected_v<have_error_field, RpcReturnType>)
+                {
+                    SPDLOG_DEBUG("error field detected inside the RpcReturnType");
+                    if constexpr (std::is_same_v<std::optional<std::string>, decltype(answer.error)>)
+                    {
+                        SPDLOG_DEBUG("The error field type is string, parsing it from the response body");
+                        if (auto json_data = nlohmann::json::parse(body); json_data.at("error").is_string())
+                        {
+                            answer.error = json_data.at("error").get<std::string>();
+                        }
+                        else
+                        {
+                            answer.error = body;
+                        }
+                        SPDLOG_DEBUG("The error after getting extracted is: {}", answer.error.value());
+                    }
+                }
+                answer.rpc_result_code = resp.status_code();
+                answer.raw_result      = body;
+                return answer;
+            }
+
+
+            assert(not body.empty());
+            auto json_answer       = nlohmann::json::parse(body);
+            answer.rpc_result_code = resp.status_code();
+            answer.raw_result      = body;
+            from_json(json_answer, answer);
+        }
+        catch (const std::exception& error)
+        {
+            SPDLOG_ERROR(
+                "{} l{} f[{}], exception caught {} for rpc {}, body: {}", __FUNCTION__, __LINE__, fs::path(__FILE__).filename().string(), error.what(),
+                rpc_command, body);
+            answer.rpc_result_code = -1;
+            answer.raw_result      = error.what();
+        }
+
+        return answer;
+    }
+
+    pplx::task<web::http::http_response>
+    mm2_client::async_rpc_batch_standalone(nlohmann::json batch_array)
+    {
+        web::http::http_request request;
+        request.set_method(web::http::methods::POST);
+        request.set_body(batch_array.dump());
+        auto resp = generate_client().request(request, m_token_source.get_token());
+        return resp;
+    }
+
+    void
+    mm2_client::stop()
+    {
+        m_token_source.cancel();
+    }
+
+    template <typename TRequest, typename TAnswer>
+    TAnswer
+    mm2_client::process_rpc(TRequest&& request, std::string rpc_command)
+    {
+        SPDLOG_INFO("Processing rpc call: {}", rpc_command);
+
+        nlohmann::json json_data = ::mm2::api::template_request(rpc_command);
+
+        ::mm2::api::to_json(json_data, request);
+
+        auto json_copy        = json_data;
+        json_copy["userpass"] = "*******";
+        SPDLOG_DEBUG("request: {}", json_copy.dump());
+
+        web::http::http_request rpc_request(web::http::methods::POST);
+        rpc_request.headers().set_content_type(FROM_STD_STR("application/json"));
+        rpc_request.set_body(json_data.dump());
+        auto resp = generate_client().request(rpc_request).get();
+        return rpc_process_answer<TAnswer>(resp, rpc_command);
+    }
+
+    t_disable_coin_answer
+    mm2_client::rpc_disable_coin(t_disable_coin_request&& request)
+    {
+        return process_rpc<t_disable_coin_request, t_disable_coin_answer>(std::forward<t_disable_coin_request>(request), "disable_coin");
+    }
+
+    t_recover_funds_of_swap_answer
+    mm2_client::rpc_recover_funds(t_recover_funds_of_swap_request&& request)
+    {
+        return process_rpc<t_recover_funds_of_swap_request, t_recover_funds_of_swap_answer>(
+            std::forward<t_recover_funds_of_swap_request>(request), "recover_funds_of_swap");
+    }
+} // namespace atomic_dex
+
+template mm2::api::tx_history_answer   atomic_dex::mm2_client::rpc_process_answer(const web::http::http_response& resp, const std::string& rpc_command);
+template mm2::api::disable_coin_answer atomic_dex::mm2_client::rpc_process_answer(const web::http::http_response& resp, const std::string& rpc_command);

--- a/src/core/atomicdex/api/mm2/mm2.client.hpp
+++ b/src/core/atomicdex/api/mm2/mm2.client.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <atomicdex/utilities/cpprestsdk.utilities.hpp>
+
+//!
+#include "atomicdex/api/mm2/rpc.disable.hpp"
+#include "atomicdex/api/mm2/rpc.recover.funds.hpp"
+
+namespace atomic_dex
+{
+    class mm2_client
+    {
+        pplx::cancellation_token_source m_token_source;
+
+      public:
+        mm2_client()  = default;
+        ~mm2_client() = default;
+
+        //! Create the client
+        void stop();
+
+        //! API
+        pplx::task<web::http::http_response> async_rpc_batch_standalone(nlohmann::json batch_array);
+
+        //! Synced
+        template <typename TRequest, typename TAnswer>
+        TAnswer process_rpc(TRequest&& request, std::string rpc_command);
+
+        template <typename RpcReturnType>
+        RpcReturnType rpc_process_answer(const web::http::http_response& resp, const std::string& rpc_command);
+
+        t_disable_coin_answer          rpc_disable_coin(t_disable_coin_request&& request);
+        t_recover_funds_of_swap_answer rpc_recover_funds(t_recover_funds_of_swap_request&& request);
+    };
+} // namespace atomic_dex

--- a/src/core/atomicdex/api/mm2/mm2.client.hpp
+++ b/src/core/atomicdex/api/mm2/mm2.client.hpp
@@ -1,14 +1,16 @@
 #pragma once
 
-#include <atomicdex/utilities/cpprestsdk.utilities.hpp>
+//! Deps
+#include <entt/core/attribute.h>
 
-//!
+//! Project Headers
+#include "atomicdex/utilities/cpprestsdk.utilities.hpp"
 #include "atomicdex/api/mm2/rpc.disable.hpp"
 #include "atomicdex/api/mm2/rpc.recover.funds.hpp"
 
 namespace atomic_dex
 {
-    class mm2_client
+    class ENTT_API mm2_client
     {
         pplx::cancellation_token_source m_token_source;
 

--- a/src/core/atomicdex/api/mm2/mm2.hpp
+++ b/src/core/atomicdex/api/mm2/mm2.hpp
@@ -300,22 +300,6 @@ namespace mm2::api
 
     send_raw_transaction_answer rpc_send_raw_transaction(send_raw_transaction_request&& request, std::shared_ptr<t_http_client> mm2_client);
 
-    struct setprice_request
-    {
-        std::string                base;
-        std::string                rel;
-        std::string                price;
-        std::string                volume;
-        bool                       max{false};
-        bool                       cancel_previous{false};
-        std::optional<bool>        base_nota;
-        std::optional<std::size_t> base_confs;
-        std::optional<bool>        rel_nota;
-        std::optional<std::size_t> rel_confs;
-    };
-
-    void to_json(nlohmann::json& j, const setprice_request& request);
-
     struct cancel_order_request
     {
         std::string uuid;
@@ -488,7 +472,6 @@ namespace mm2::api
 namespace atomic_dex
 {
     using t_my_orders_answer        = ::mm2::api::my_orders_answer;
-    using t_setprice_request        = ::mm2::api::setprice_request;
     using t_withdraw_request        = ::mm2::api::withdraw_request;
     using t_withdraw_fees           = ::mm2::api::withdraw_fees;
     using t_withdraw_answer         = ::mm2::api::withdraw_answer;

--- a/src/core/atomicdex/api/mm2/mm2.hpp
+++ b/src/core/atomicdex/api/mm2/mm2.hpp
@@ -21,7 +21,6 @@
 
 //! Deps
 #include <antara/gaming/ecs/system.manager.hpp>
-#include <meta/detection/detection.hpp>
 #include <nlohmann/json.hpp>
 
 //! Project Headers
@@ -42,67 +41,9 @@ namespace mm2::api
     inline std::unique_ptr<web::http::client::http_client> g_qtum_proxy_http_client{
         std::make_unique<web::http::client::http_client>(FROM_STD_STR(::atomic_dex::g_qtum_infos_endpoint))};
 
-    pplx::task<web::http::http_response>
-                   async_rpc_batch_standalone(nlohmann::json batch_array, std::shared_ptr<t_http_client> mm2_client, pplx::cancellation_token token);
     nlohmann::json basic_batch_answer(const web::http::http_response& resp);
 
     std::string rpc_version();
-
-    struct disable_coin_request
-    {
-        std::string coin;
-    };
-
-    void to_json(nlohmann::json& j, const disable_coin_request& req);
-
-    struct disable_coin_answer_success
-    {
-        std::string coin;
-    };
-
-    void from_json(const nlohmann::json& j, disable_coin_answer_success& resp);
-
-    struct disable_coin_answer
-    {
-        std::optional<std::string>                 error;
-        std::optional<disable_coin_answer_success> result;
-        int                                        rpc_result_code;
-        std::string                                raw_result;
-    };
-
-    void from_json(const nlohmann::json& j, disable_coin_answer& resp);
-
-    disable_coin_answer rpc_disable_coin(disable_coin_request&& request, std::shared_ptr<t_http_client> mm2_client);
-
-    struct recover_funds_of_swap_request
-    {
-        std::string swap_uuid;
-    };
-
-    void to_json(nlohmann::json& j, const recover_funds_of_swap_request& cfg);
-
-    struct recover_funds_of_swap_answer_success
-    {
-        std::string action;
-        std::string coin;
-        std::string tx_hash;
-        std::string tx_hex;
-    };
-
-    void from_json(const nlohmann::json& j, recover_funds_of_swap_answer_success& answer);
-
-    struct recover_funds_of_swap_answer
-    {
-        std::optional<std::string>                          error;
-        std::optional<recover_funds_of_swap_answer_success> result;
-        int                                                 rpc_result_code;
-        std::string                                         raw_result;
-    };
-
-    void from_json(const nlohmann::json& j, recover_funds_of_swap_answer& answer);
-
-    recover_funds_of_swap_answer rpc_recover_funds(recover_funds_of_swap_request&& request, std::shared_ptr<t_http_client> mm2_client);
-
 
     struct trade_fee_request
     {
@@ -448,21 +389,12 @@ namespace mm2::api
     // kmd_rewards_info_answer rpc_kmd_rewards_info(std::shared_ptr<t_http_client> mm2_client);
     kmd_rewards_info_answer process_kmd_rewards_answer(nlohmann::json result);
 
-    template <typename T>
-    using have_error_field = decltype(std::declval<T&>().error.has_value());
-
-    template <typename RpcReturnType>
-    RpcReturnType rpc_process_answer(const web::http::http_response& resp, const std::string& rpc_command) ;
-
     template <typename RpcReturnType>
     RpcReturnType rpc_process_answer_batch(nlohmann::json& json_answer, const std::string& rpc_command) ;
 
     pplx::task<web::http::http_response> async_process_rpc_get(t_http_client_ptr& client, const std::string rpc_command, const std::string& url);
 
     nlohmann::json template_request(std::string method_name) ;
-
-    template <typename TRequest, typename TAnswer>
-    static TAnswer process_rpc(TRequest&& request, std::string rpc_command, std::shared_ptr<t_http_client> http_mm2_client);
 
     void               set_rpc_password(std::string rpc_password) ;
     const std::string& get_rpc_password() ;
@@ -476,7 +408,6 @@ namespace atomic_dex
     using t_withdraw_fees           = ::mm2::api::withdraw_fees;
     using t_withdraw_answer         = ::mm2::api::withdraw_answer;
     using t_broadcast_request       = ::mm2::api::send_raw_transaction_request;
-    using t_disable_coin_request    = ::mm2::api::disable_coin_request;
     using t_tx_history_request      = ::mm2::api::tx_history_request;
     using t_my_recent_swaps_answer  = ::mm2::api::my_recent_swaps_answer;
     using t_my_recent_swaps_request = ::mm2::api::my_recent_swaps_request;

--- a/src/core/atomicdex/api/mm2/rpc.disable.cpp
+++ b/src/core/atomicdex/api/mm2/rpc.disable.cpp
@@ -1,0 +1,32 @@
+//
+// Created by Sztergbaum Roman on 27/03/2021.
+//
+
+#include <nlohmann/json.hpp>
+
+//!
+#include "atomicdex/api/mm2/generics.hpp"
+#include "atomicdex/api/mm2/rpc.disable.hpp"
+
+namespace mm2::api
+{
+    //! Serialization
+    void
+    to_json(nlohmann::json& j, const disable_coin_request& req)
+    {
+        j["coin"] = req.coin;
+    }
+
+    //! Deserialization
+    void
+    from_json(const nlohmann::json& j, disable_coin_answer_success& resp)
+    {
+        j.at("coin").get_to(resp.coin);
+    }
+
+    void
+    from_json(const nlohmann::json& j, disable_coin_answer& resp)
+    {
+        extract_rpc_json_answer<disable_coin_answer_success>(j, resp);
+    }
+} // namespace mm2::api

--- a/src/core/atomicdex/api/mm2/rpc.disable.hpp
+++ b/src/core/atomicdex/api/mm2/rpc.disable.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+//! JSON FWD
+#include <nlohmann/json_fwd.hpp>
+
+namespace mm2::api
+{
+    struct disable_coin_request
+    {
+        std::string coin;
+    };
+
+    void to_json(nlohmann::json& j, const disable_coin_request& req);
+
+    struct disable_coin_answer_success
+    {
+        std::string coin;
+    };
+
+    void from_json(const nlohmann::json& j, disable_coin_answer_success& resp);
+
+    struct disable_coin_answer
+    {
+        std::optional<std::string>                 error;
+        std::optional<disable_coin_answer_success> result;
+        int                                        rpc_result_code;
+        std::string                                raw_result;
+    };
+
+    void from_json(const nlohmann::json& j, disable_coin_answer& resp);
+} // namespace mm2::api
+
+namespace atomic_dex
+{
+    using t_disable_coin_request = ::mm2::api::disable_coin_request;
+    using t_disable_coin_answer = ::mm2::api::disable_coin_answer;
+}

--- a/src/core/atomicdex/api/mm2/rpc.recover.funds.cpp
+++ b/src/core/atomicdex/api/mm2/rpc.recover.funds.cpp
@@ -1,0 +1,41 @@
+//
+// Created by Sztergbaum Roman on 27/03/2021.
+//
+
+//! Deps
+#include <nlohmann/json.hpp>
+
+//! Project Headers
+#include "atomicdex/api/mm2/rpc.recover.funds.hpp"
+
+namespace mm2::api
+{
+    void
+    to_json(nlohmann::json& j, const recover_funds_of_swap_request& cfg)
+    {
+        j["params"]         = nlohmann::json::object();
+        j["params"]["uuid"] = cfg.swap_uuid;
+    }
+
+    void
+    from_json(const nlohmann::json& j, recover_funds_of_swap_answer_success& answer)
+    {
+        j.at("action").get_to(answer.action);
+        j.at("coin").get_to(answer.coin);
+        j.at("tx_hash").get_to(answer.tx_hash);
+        j.at("tx_hex").get_to(answer.tx_hex);
+    }
+
+    void
+    from_json(const nlohmann::json& j, recover_funds_of_swap_answer& answer)
+    {
+        if (j.count("error") == 1)
+        {
+            answer.error = j.at("error").get<std::string>();
+        }
+        else
+        {
+            answer.result = j.at("result").get<recover_funds_of_swap_answer_success>();
+        }
+    }
+}

--- a/src/core/atomicdex/api/mm2/rpc.recover.funds.hpp
+++ b/src/core/atomicdex/api/mm2/rpc.recover.funds.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+//! Deps
+#include <nlohmann/json_fwd.hpp>
+
+namespace mm2::api
+{
+    struct recover_funds_of_swap_request
+    {
+        std::string swap_uuid;
+    };
+
+    void to_json(nlohmann::json& j, const recover_funds_of_swap_request& cfg);
+
+    struct recover_funds_of_swap_answer_success
+    {
+        std::string action;
+        std::string coin;
+        std::string tx_hash;
+        std::string tx_hex;
+    };
+
+    void from_json(const nlohmann::json& j, recover_funds_of_swap_answer_success& answer);
+
+    struct recover_funds_of_swap_answer
+    {
+        std::optional<std::string>                          error;
+        std::optional<recover_funds_of_swap_answer_success> result;
+        int                                                 rpc_result_code;
+        std::string                                         raw_result;
+    };
+
+    void from_json(const nlohmann::json& j, recover_funds_of_swap_answer& answer);
+} // namespace mm2::api
+
+namespace atomic_dex
+{
+    using t_recover_funds_of_swap_request = ::mm2::api::recover_funds_of_swap_request;
+    using t_recover_funds_of_swap_answer  = ::mm2::api::recover_funds_of_swap_answer;
+} // namespace atomic_dex

--- a/src/core/atomicdex/api/mm2/rpc.setprice.cpp
+++ b/src/core/atomicdex/api/mm2/rpc.setprice.cpp
@@ -1,0 +1,54 @@
+/******************************************************************************
+ * Copyright © 2013-2021 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+#include <nlohmann/json.hpp>
+
+//! Project Headers
+#include "atomicdex/api/mm2/rpc.setprice.hpp"
+
+namespace mm2::api
+{
+    void
+    to_json(nlohmann::json& j, const setprice_request& request)
+    {
+        j["base"]            = request.base;
+        j["price"]           = request.price;
+        j["rel"]             = request.rel;
+        j["volume"]          = request.volume;
+        j["cancel_previous"] = request.cancel_previous;
+        j["max"]             = request.max;
+        if (request.base_nota.has_value())
+        {
+            j["base_nota"] = request.base_nota.value();
+        }
+        if (request.base_confs.has_value())
+        {
+            j["base_confs"] = request.base_confs.value();
+        }
+        if (request.rel_nota.has_value())
+        {
+            j["rel_nota"] = request.rel_nota.value();
+        }
+        if (request.rel_confs.has_value())
+        {
+            j["rel_confs"] = request.rel_confs.value();
+        }
+        if (request.min_volume.has_value())
+        {
+            j["min_volume"] = request.min_volume.value();
+        }
+    }
+}

--- a/src/core/atomicdex/api/mm2/rpc.setprice.hpp
+++ b/src/core/atomicdex/api/mm2/rpc.setprice.hpp
@@ -1,0 +1,49 @@
+/******************************************************************************
+ * Copyright © 2013-2021 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+#pragma once
+
+//! STD
+#include <string>
+#include <optional>
+
+//! Deps
+#include <nlohmann/json_fwd.hpp>
+
+namespace mm2::api
+{
+    struct setprice_request
+    {
+        std::string                base;
+        std::string                rel;
+        std::string                price;
+        std::string                volume;
+        bool                       max{false};
+        bool                       cancel_previous{false};
+        std::optional<bool>        base_nota;
+        std::optional<std::size_t> base_confs;
+        std::optional<bool>        rel_nota;
+        std::optional<std::size_t> rel_confs;
+        std::optional<std::string> min_volume;
+    };
+
+    void to_json(nlohmann::json& j, const setprice_request& request);
+}
+
+namespace atomic_dex
+{
+    using t_setprice_request        = ::mm2::api::setprice_request;
+}

--- a/src/core/atomicdex/data/dex/qt.orders.data.hpp
+++ b/src/core/atomicdex/data/dex/qt.orders.data.hpp
@@ -3,6 +3,12 @@
 #include <QJsonArray>
 #include <QString>
 
+//! STD
+#include <optional>
+
+//! deps
+#include <nlohmann/json.hpp>
+
 namespace mm2::api
 {
     struct order_swaps_data
@@ -75,6 +81,10 @@ namespace mm2::api
         QStringList success_events;
 
         bool is_swap_active{false};
+
+        //! Only available for maker order
+        std::optional<QString>        min_volume{std::nullopt};
+        std::optional<nlohmann::json> conf_settings{std::nullopt};
     };
 } // namespace mm2::api
 

--- a/src/core/atomicdex/models/qt.orders.model.hpp
+++ b/src/core/atomicdex/models/qt.orders.model.hpp
@@ -76,8 +76,8 @@ namespace atomic_dex
         };
 
         //! Constructor / destructor
-        orders_model(ag::ecs::system_manager& system_manager, entt::dispatcher& dispatcher, QObject* parent = nullptr) ;
-        ~orders_model()  final = default;
+        orders_model(ag::ecs::system_manager& system_manager, entt::dispatcher& dispatcher, QObject* parent = nullptr);
+        ~orders_model() final = default;
 
         //! Official override from Qt Model
         int                    rowCount(const QModelIndex& parent = QModelIndex()) const final;
@@ -88,25 +88,25 @@ namespace atomic_dex
 
         //! Public api
         void refresh_or_insert(bool after_manual_reset = false);
-        void reset() ;
-        void reset_backend() ;
-        bool swap_is_in_progress(const QString& coin) const ;
+        void reset();
+        void reset_backend(const std::string& from);
+        bool swap_is_in_progress(const QString& coin) const;
 
         //! Properties
-        [[nodiscard]] int                 get_length() const ;
-        [[nodiscard]] orders_proxy_model* get_orders_proxy_mdl() const ;
-        [[nodiscard]] QVariant            get_average_events_time_registry() const ;
-        [[nodiscard]] int                 get_current_page() const ;
-        void                              set_current_page(int current_page) ;
-        [[nodiscard]] int                 get_limit_nb_elements() const ;
-        void                              set_limit_nb_elements(int limit) ;
-        [[nodiscard]] bool                is_fetching_busy() const ;
-        void                              set_fetching_busy(bool fetching_status) ;
-        [[nodiscard]] int                 get_nb_pages() const ;
+        [[nodiscard]] int                 get_length() const;
+        [[nodiscard]] orders_proxy_model* get_orders_proxy_mdl() const;
+        [[nodiscard]] QVariant            get_average_events_time_registry() const;
+        [[nodiscard]] int                 get_current_page() const;
+        void                              set_current_page(int current_page);
+        [[nodiscard]] int                 get_limit_nb_elements() const;
+        void                              set_limit_nb_elements(int limit);
+        [[nodiscard]] bool                is_fetching_busy() const;
+        void                              set_fetching_busy(bool fetching_status);
+        [[nodiscard]] int                 get_nb_pages() const;
 
         //! getter
-        [[nodiscard]] t_filtering_infos get_filtering_infos() const ;
-        void                            set_filtering_infos(t_filtering_infos infos) ;
+        [[nodiscard]] t_filtering_infos get_filtering_infos() const;
+        void                            set_filtering_infos(t_filtering_infos infos);
 
 
       signals:
@@ -119,7 +119,7 @@ namespace atomic_dex
         void nbPageChanged();
 
       private:
-        void set_average_events_time_registry(const QVariant& average_time_registry) ;
+        void set_average_events_time_registry(const QVariant& average_time_registry);
         void common_insert(const std::vector<t_order_swaps_data>& contents, const std::string& kind);
 
         ag::ecs::system_manager& m_system_manager;
@@ -139,18 +139,18 @@ namespace atomic_dex
 
         //! Private common API
         void init_model(const orders_and_swaps& contents);
-        void set_common_data(const orders_and_swaps& contents) ;
+        void set_common_data(const orders_and_swaps& contents);
 
         //! Private orders API
         void update_or_insert_orders(const orders_and_swaps& contents);
         void remove_orders(const t_orders_id_registry& are_present);
-        void update_existing_order(const t_order_swaps_data& contents) ;
+        void update_existing_order(const t_order_swaps_data& contents);
 
         //! Private Swaps API
         void update_or_insert_swaps(const orders_and_swaps& contents);
-        void update_swap(const t_order_swaps_data& contents) ;
+        void update_swap(const t_order_swaps_data& contents);
 
         //! Events
-        void on_current_currency_changed(const current_currency_changed&) ;
+        void on_current_currency_changed(const current_currency_changed&);
     };
 } // namespace atomic_dex

--- a/src/core/atomicdex/models/qt.orders.proxy.model.cpp
+++ b/src/core/atomicdex/models/qt.orders.proxy.model.cpp
@@ -247,16 +247,16 @@ namespace atomic_dex
     void
     orders_proxy_model::set_coin_filter(const QString& to_filter)
     {
-        SPDLOG_INFO("filter pattern: {}", to_filter.toStdString());
+        SPDLOG_INFO("filter pattern: {}, is_history: {}", to_filter.toStdString(), m_is_history);
         this->setFilterFixedString(to_filter);
         if (this->m_is_history)
         {
             this->set_apply_filtering(true);
         }
-        else
-        {
-            emit qobject_cast<orders_model*>(this->sourceModel())->lengthChanged();
-        }
+        //else
+        //{
+            //emit qobject_cast<orders_model*>(this->sourceModel())->lengthChanged();
+        //}
     }
 
     void

--- a/src/core/atomicdex/pages/qt.settings.page.cpp
+++ b/src/core/atomicdex/pages/qt.settings.page.cpp
@@ -596,7 +596,7 @@ namespace atomic_dex
                 }
                 this->set_fetching_priv_key_busy(false);
             };
-            ::mm2::api::async_rpc_batch_standalone(batch, mm2_system.get_mm2_client(), pplx::cancellation_token::none()).then(answer_functor);
+            mm2_system.get_mm2_client().async_rpc_batch_standalone(batch).then(answer_functor);
         }
         return {QString::fromStdString(seed), QString::fromStdString(::mm2::api::get_rpc_password())};
     }

--- a/src/core/atomicdex/pages/qt.trading.page.cpp
+++ b/src/core/atomicdex/pages/qt.trading.page.cpp
@@ -23,6 +23,7 @@
 #include "atomicdex/pages/qt.portfolio.page.hpp"
 #include "atomicdex/pages/qt.settings.page.hpp"
 #include "atomicdex/pages/qt.trading.page.hpp"
+#include "atomicdex/services/mm2/auto.update.maker.order.service.hpp"
 #include "atomicdex/services/mm2/mm2.service.hpp"
 #include "atomicdex/services/price/global.provider.hpp"
 #include "atomicdex/utilities/qt.utilities.hpp"
@@ -46,7 +47,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     void
-    trading_page::on_process_orderbook_finished_event(const atomic_dex::process_orderbook_finished& evt) 
+    trading_page::on_process_orderbook_finished_event(const atomic_dex::process_orderbook_finished& evt)
     {
         if (not m_about_to_exit_the_app)
         {
@@ -61,7 +62,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     QVariant
-    trading_page::get_raw_mm2_coin_cfg(const QString& ticker) const 
+    trading_page::get_raw_mm2_coin_cfg(const QString& ticker) const
     {
         QVariant       out;
         nlohmann::json j = m_system_manager.get_system<mm2_service>().get_raw_mm2_ticker_cfg(ticker.toStdString());
@@ -102,6 +103,10 @@ namespace atomic_dex
     trading_page::on_gui_enter_dex()
     {
         dispatcher_.trigger<gui_enter_trading>();
+        if (this->m_system_manager.has_system<auto_update_maker_order_service>())
+        {
+            this->m_system_manager.get_system<auto_update_maker_order_service>().force_update();
+        }
     }
 
     void
@@ -347,7 +352,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     void
-    trading_page::disable_coins(const QStringList& coins) 
+    trading_page::disable_coins(const QStringList& coins)
     {
         for (auto&& coin: coins)
         {
@@ -373,7 +378,7 @@ namespace atomic_dex
     }
 
     void
-    trading_page::update() 
+    trading_page::update()
     {
     }
 
@@ -426,31 +431,31 @@ namespace atomic_dex
 namespace atomic_dex
 {
     qt_orderbook_wrapper*
-    trading_page::get_orderbook_wrapper() const 
+    trading_page::get_orderbook_wrapper() const
     {
         return qobject_cast<qt_orderbook_wrapper*>(m_models[models::orderbook]);
     }
 
     qt_orders_widget*
-    trading_page::get_orders_widget() const 
+    trading_page::get_orders_widget() const
     {
         return qobject_cast<qt_orders_widget*>(m_models[models::orders]);
     }
 
     market_pairs*
-    trading_page::get_market_pairs_mdl() const 
+    trading_page::get_market_pairs_mdl() const
     {
         return qobject_cast<market_pairs*>(m_models[models::market_selector]);
     }
 
     bool
-    trading_page::is_buy_sell_rpc_busy() const 
+    trading_page::is_buy_sell_rpc_busy() const
     {
         return m_rpc_buy_sell_busy.load();
     }
 
     void
-    trading_page::set_buy_sell_rpc_busy(bool status) 
+    trading_page::set_buy_sell_rpc_busy(bool status)
     {
         if (m_rpc_buy_sell_busy != status)
         {
@@ -460,13 +465,13 @@ namespace atomic_dex
     }
 
     QVariant
-    trading_page::get_buy_sell_last_rpc_data() const 
+    trading_page::get_buy_sell_last_rpc_data() const
     {
         return m_rpc_buy_sell_result.get();
     }
 
     void
-    trading_page::set_buy_sell_last_rpc_data(QVariant rpc_data) 
+    trading_page::set_buy_sell_last_rpc_data(QVariant rpc_data)
     {
         m_rpc_buy_sell_result = rpc_data.toJsonObject();
         emit buySellLastRpcDataChanged();
@@ -477,13 +482,13 @@ namespace atomic_dex
 namespace atomic_dex
 {
     MarketMode
-    trading_page::get_market_mode() const 
+    trading_page::get_market_mode() const
     {
         return m_market_mode;
     }
 
     void
-    trading_page::set_market_mode(MarketMode market_mode) 
+    trading_page::set_market_mode(MarketMode market_mode)
     {
         if (this->m_market_mode != market_mode)
         {
@@ -505,13 +510,13 @@ namespace atomic_dex
     }
 
     QString
-    trading_page::get_price() const 
+    trading_page::get_price() const
     {
         return m_price;
     }
 
     void
-    trading_page::set_price(QString price) 
+    trading_page::set_price(QString price)
     {
         if (price.isEmpty())
         {
@@ -549,7 +554,7 @@ namespace atomic_dex
     }
 
     void
-    trading_page::clear_forms() 
+    trading_page::clear_forms()
     {
         SPDLOG_INFO("clearing forms");
         this->set_min_trade_vol(get_mm2_min_trade_vol());
@@ -569,13 +574,13 @@ namespace atomic_dex
     }
 
     QString
-    trading_page::get_volume() const 
+    trading_page::get_volume() const
     {
         return m_volume;
     }
 
     void
-    trading_page::set_volume(QString volume) 
+    trading_page::set_volume(QString volume)
     {
         if (m_volume != volume && not volume.isEmpty())
         {
@@ -595,13 +600,13 @@ namespace atomic_dex
     }
 
     QString
-    trading_page::get_max_volume() const 
+    trading_page::get_max_volume() const
     {
         return m_max_volume;
     }
 
     void
-    trading_page::set_max_volume(QString max_volume) 
+    trading_page::set_max_volume(QString max_volume)
     {
         if (m_max_volume != max_volume)
         {
@@ -612,7 +617,7 @@ namespace atomic_dex
     }
 
     void
-    trading_page::determine_max_volume() 
+    trading_page::determine_max_volume()
     {
         if (this->m_market_mode == MarketMode::Sell)
         {
@@ -697,7 +702,7 @@ namespace atomic_dex
     }
 
     void
-    trading_page::cap_volume() 
+    trading_page::cap_volume()
     {
         /*
          * cap_volume is called only in MarketMode::Buy, and in Sell mode if prefered order
@@ -713,13 +718,13 @@ namespace atomic_dex
     }
 
     TradingError
-    trading_page::get_trading_error() const 
+    trading_page::get_trading_error() const
     {
         return m_last_trading_error;
     }
 
     void
-    trading_page::set_trading_error(TradingError trading_error) 
+    trading_page::set_trading_error(TradingError trading_error)
     {
         if (m_last_trading_error != trading_error)
         {
@@ -762,13 +767,13 @@ namespace atomic_dex
     }
 
     TradingMode
-    trading_page::get_current_trading_mode() const 
+    trading_page::get_current_trading_mode() const
     {
         return m_current_trading_mode;
     }
 
     void
-    trading_page::set_current_trading_mode(TradingMode trading_mode) 
+    trading_page::set_current_trading_mode(TradingMode trading_mode)
     {
         if (m_current_trading_mode != trading_mode)
         {
@@ -781,7 +786,7 @@ namespace atomic_dex
     }
 
     bool
-    trading_page::set_pair(bool is_left_side, QString changed_ticker) 
+    trading_page::set_pair(bool is_left_side, QString changed_ticker)
     {
         SPDLOG_INFO("Changed ticker: {}", changed_ticker.toStdString());
         auto* const market_pair = get_market_pairs_mdl();
@@ -844,7 +849,7 @@ namespace atomic_dex
     }
 
     QVariantMap
-    trading_page::get_preffered_order() 
+    trading_page::get_preffered_order()
     {
         if (m_preffered_order.has_value())
         {
@@ -855,7 +860,7 @@ namespace atomic_dex
     }
 
     void
-    trading_page::set_preffered_order(QVariantMap price_object) 
+    trading_page::set_preffered_order(QVariantMap price_object)
     {
         if (auto preffered_order = nlohmann::json::parse(QString(QJsonDocument(QJsonObject::fromVariantMap(price_object)).toJson()).toStdString());
             preffered_order != m_preffered_order)
@@ -873,13 +878,13 @@ namespace atomic_dex
     }
 
     QString
-    trading_page::get_total_amount() const 
+    trading_page::get_total_amount() const
     {
         return m_total_amount;
     }
 
     void
-    trading_page::set_total_amount(QString total_amount) 
+    trading_page::set_total_amount(QString total_amount)
     {
         if (this->m_current_trading_mode != TradingMode::Simple)
         {
@@ -910,7 +915,7 @@ namespace atomic_dex
     }
 
     void
-    trading_page::determine_total_amount() 
+    trading_page::determine_total_amount()
     {
         if (not m_price.isEmpty() && not m_volume.isEmpty())
         {
@@ -929,25 +934,25 @@ namespace atomic_dex
     }
 
     QString
-    trading_page::get_base_amount() const 
+    trading_page::get_base_amount() const
     {
         return m_market_mode == MarketMode::Sell ? m_volume : m_total_amount;
     }
 
     QString
-    trading_page::get_rel_amount() const 
+    trading_page::get_rel_amount() const
     {
         return m_market_mode == MarketMode::Sell ? m_total_amount : m_volume;
     }
 
     QVariantMap
-    trading_page::get_fees() const 
+    trading_page::get_fees() const
     {
         return m_fees.get();
     }
 
     void
-    trading_page::set_fees(QVariantMap fees) 
+    trading_page::set_fees(QVariantMap fees)
     {
         if (fees != m_fees)
         {
@@ -958,27 +963,23 @@ namespace atomic_dex
     }
 
     void
-    trading_page::determine_fees() 
+    trading_page::determine_fees()
     {
         using namespace std::string_literals;
         const auto* market_pair = get_market_pairs_mdl();
         auto&       mm2         = this->m_system_manager.get_system<mm2_service>();
         const auto  base        = market_pair->get_left_selected_coin().toStdString();
         const auto  rel         = market_pair->get_right_selected_coin().toStdString();
-        //const bool  is_max      = m_market_mode == MarketMode::Sell && m_volume == m_max_volume;
-        const auto  swap_method = m_market_mode == MarketMode::Sell ? "sell"s : "buy"s;
+        // const bool  is_max      = m_market_mode == MarketMode::Sell && m_volume == m_max_volume;
+        const auto swap_method = m_market_mode == MarketMode::Sell ? "sell"s : "buy"s;
 
         t_trade_preimage_request req{
-            .base_coin   = base,
-            .rel_coin    = rel,
-            .swap_method = swap_method,
-            .volume      = get_volume().toStdString(),
-            .price       = get_price().toStdString()};
+            .base_coin = base, .rel_coin = rel, .swap_method = swap_method, .volume = get_volume().toStdString(), .price = get_price().toStdString()};
 
         nlohmann::json batch;
         nlohmann::json preimage_request = ::mm2::api::template_request("trade_preimage");
         ::mm2::api::to_json(preimage_request, req);
-        //SPDLOG_INFO("request: {}", preimage_request.dump(4));
+        // SPDLOG_INFO("request: {}", preimage_request.dump(4));
         batch.push_back(preimage_request);
 
         this->set_preimage_busy(true);
@@ -986,10 +987,10 @@ namespace atomic_dex
             std::string body = TO_STD_STR(resp.extract_string(true).get());
             if (resp.status_code() == 200)
             {
-                auto           answers               = nlohmann::json::parse(body);
-                nlohmann::json answer                = answers[0];
-                //SPDLOG_INFO("preimage answer: {}", answer.dump(4));
-                auto           trade_preimage_answer = ::mm2::api::rpc_process_answer_batch<t_trade_preimage_answer>(answer, "trade_preimage");
+                auto           answers = nlohmann::json::parse(body);
+                nlohmann::json answer  = answers[0];
+                // SPDLOG_INFO("preimage answer: {}", answer.dump(4));
+                auto trade_preimage_answer = ::mm2::api::rpc_process_answer_batch<t_trade_preimage_answer>(answer, "trade_preimage");
                 if (trade_preimage_answer.result.has_value())
                 {
                     const auto  success_answer = trade_preimage_answer.result.value();
@@ -1031,7 +1032,7 @@ namespace atomic_dex
     }
 
     void
-    trading_page::determine_error_cases() 
+    trading_page::determine_error_cases()
     {
         TradingError current_trading_error = TradingError::None;
 
@@ -1072,7 +1073,7 @@ namespace atomic_dex
     }
 
     void
-    trading_page::determine_cex_rates() 
+    trading_page::determine_cex_rates()
     {
         const auto& price_service   = m_system_manager.get_system<global_price_service>();
         const auto* market_selector = get_market_pairs_mdl();
@@ -1090,19 +1091,19 @@ namespace atomic_dex
     }
 
     QString
-    trading_page::get_cex_price() const 
+    trading_page::get_cex_price() const
     {
         return m_cex_price;
     }
 
     bool
-    trading_page::get_invalid_cex_price() const 
+    trading_page::get_invalid_cex_price() const
     {
         return m_cex_price == "0" || m_cex_price == "0.00" || m_cex_price.isEmpty();
     }
 
     QString
-    trading_page::get_price_reversed() const 
+    trading_page::get_price_reversed() const
     {
         if (not m_price.isEmpty() && safe_float(m_price.toStdString()) > 0)
         {
@@ -1114,7 +1115,7 @@ namespace atomic_dex
     }
 
     QString
-    trading_page::get_cex_price_reversed() const 
+    trading_page::get_cex_price_reversed() const
     {
         if (not get_invalid_cex_price())
         {
@@ -1125,7 +1126,7 @@ namespace atomic_dex
     }
 
     QString
-    trading_page::get_cex_price_diff() const 
+    trading_page::get_cex_price_diff() const
     {
         t_float_50 price_diff = get_invalid_cex_price()
                                     ? t_float_50(0)
@@ -1135,7 +1136,7 @@ namespace atomic_dex
     }
 
     t_float_50
-    trading_page::get_max_balance_without_dust(std::optional<QString> trade_with) const 
+    trading_page::get_max_balance_without_dust(std::optional<QString> trade_with) const
     {
         if (!trade_with.has_value())
         {
@@ -1153,7 +1154,7 @@ namespace atomic_dex
     }
 
     TradingError
-    trading_page::generate_fees_error(QVariantMap fees, t_float_50 max_balance_without_dust) const 
+    trading_page::generate_fees_error(QVariantMap fees, t_float_50 max_balance_without_dust) const
     {
         TradingError last_trading_error = TradingError::None;
         const auto&  mm2                = m_system_manager.get_system<mm2_service>();
@@ -1195,13 +1196,13 @@ namespace atomic_dex
     }
 
     bool
-    trading_page::get_skip_taker() const 
+    trading_page::get_skip_taker() const
     {
         return m_skip_taker;
     }
 
     void
-    trading_page::set_skip_taker(bool skip_taker) 
+    trading_page::set_skip_taker(bool skip_taker)
     {
         if (m_skip_taker != skip_taker)
         {
@@ -1211,7 +1212,7 @@ namespace atomic_dex
     }
 
     QString
-    trading_page::get_mm2_min_trade_vol() const 
+    trading_page::get_mm2_min_trade_vol() const
     {
         const auto& mm2           = m_system_manager.get_system<mm2_service>();
         const auto  base_coin     = get_market_pairs_mdl()->get_base_selected_coin().toStdString();
@@ -1227,13 +1228,13 @@ namespace atomic_dex
     }
 
     QString
-    trading_page::get_min_trade_vol() const 
+    trading_page::get_min_trade_vol() const
     {
         return m_minimal_trading_amount;
     }
 
     void
-    trading_page::set_min_trade_vol(QString min_trade_vol) 
+    trading_page::set_min_trade_vol(QString min_trade_vol)
     {
         const bool is_valid = safe_float(min_trade_vol.toStdString()) <= safe_float(get_volume().toStdString());
 
@@ -1244,19 +1245,19 @@ namespace atomic_dex
         }
     }
     void
-    trading_page::reset_order() 
+    trading_page::reset_order()
     {
         this->clear_forms();
     }
 
     bool
-    trading_page::is_preimage_busy() const 
+    trading_page::is_preimage_busy() const
     {
         return m_rpc_preimage_busy.load();
     }
 
     void
-    trading_page::set_preimage_busy(bool status) 
+    trading_page::set_preimage_busy(bool status)
     {
         if (status != m_rpc_preimage_busy)
         {
@@ -1265,7 +1266,7 @@ namespace atomic_dex
         }
     }
     void
-    trading_page::reset_fees() 
+    trading_page::reset_fees()
     {
         this->set_fees(QVariantMap());
         this->determine_error_cases();
@@ -1275,7 +1276,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     QString
-    trading_page::calculate_total_amount(QString price, QString volume) const 
+    trading_page::calculate_total_amount(QString price, QString volume) const
     {
         t_float_50 price_f(safe_float(price.toStdString()));
         t_float_50 volume_f(safe_float(volume.toStdString()));

--- a/src/core/atomicdex/pages/qt.trading.page.cpp
+++ b/src/core/atomicdex/pages/qt.trading.page.cpp
@@ -209,22 +209,20 @@ namespace atomic_dex
         };
 
         //! Async call
-        ::mm2::api::async_rpc_batch_standalone(batch, mm2_system.get_mm2_client(), mm2_system.get_cancellation_token())
-            .then(answer_functor)
-            .then([this]([[maybe_unused]] pplx::task<void> previous_task) {
-                try
-                {
-                    previous_task.wait();
-                }
-                catch (const std::exception& e)
-                {
-                    SPDLOG_ERROR("pplx task error: {}", e.what());
-                    auto error_json = QJsonObject({{"error_code", 500}, {"error_message", e.what()}});
-                    this->set_buy_sell_last_rpc_data(error_json);
-                    this->set_buy_sell_rpc_busy(false);
-                    this->clear_forms();
-                }
-            });
+        mm2_system.get_mm2_client().async_rpc_batch_standalone(batch).then(answer_functor).then([this]([[maybe_unused]] pplx::task<void> previous_task) {
+            try
+            {
+                previous_task.wait();
+            }
+            catch (const std::exception& e)
+            {
+                SPDLOG_ERROR("pplx task error: {}", e.what());
+                auto error_json = QJsonObject({{"error_code", 500}, {"error_message", e.what()}});
+                this->set_buy_sell_last_rpc_data(error_json);
+                this->set_buy_sell_rpc_busy(false);
+                this->clear_forms();
+            }
+        });
     }
 
     void
@@ -329,22 +327,20 @@ namespace atomic_dex
         };
 
         //! Async call
-        ::mm2::api::async_rpc_batch_standalone(batch, mm2_system.get_mm2_client(), mm2_system.get_cancellation_token())
-            .then(answer_functor)
-            .then([this]([[maybe_unused]] pplx::task<void> previous_task) {
-                try
-                {
-                    previous_task.wait();
-                }
-                catch (const std::exception& e)
-                {
-                    SPDLOG_ERROR("pplx task error: {}", e.what());
-                    auto error_json = QJsonObject({{"error_code", 500}, {"error_message", e.what()}});
-                    this->set_buy_sell_last_rpc_data(error_json);
-                    this->set_buy_sell_rpc_busy(false);
-                    this->clear_forms();
-                }
-            });
+        mm2_system.get_mm2_client().async_rpc_batch_standalone(batch).then(answer_functor).then([this]([[maybe_unused]] pplx::task<void> previous_task) {
+            try
+            {
+                previous_task.wait();
+            }
+            catch (const std::exception& e)
+            {
+                SPDLOG_ERROR("pplx task error: {}", e.what());
+                auto error_json = QJsonObject({{"error_code", 500}, {"error_message", e.what()}});
+                this->set_buy_sell_last_rpc_data(error_json);
+                this->set_buy_sell_rpc_busy(false);
+                this->clear_forms();
+            }
+        });
     }
 } // namespace atomic_dex
 
@@ -1020,9 +1016,7 @@ namespace atomic_dex
             }
             this->set_preimage_busy(false);
         };
-        ::mm2::api::async_rpc_batch_standalone(batch, mm2.get_mm2_client(), mm2.get_cancellation_token())
-            .then(answer_functor)
-            .then(&handle_exception_pplx_task);
+        mm2.get_mm2_client().async_rpc_batch_standalone(batch).then(answer_functor).then(&handle_exception_pplx_task);
 
         //! (send) BCH <-> ETH (receive)
         /*

--- a/src/core/atomicdex/pages/qt.wallet.page.cpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.cpp
@@ -27,7 +27,7 @@ namespace atomic_dex
     }
 
     void
-    wallet_page::update() 
+    wallet_page::update()
     {
     }
 } // namespace atomic_dex
@@ -36,14 +36,14 @@ namespace atomic_dex
 namespace atomic_dex
 {
     QString
-    wallet_page::get_current_ticker() const 
+    wallet_page::get_current_ticker() const
     {
         const auto& mm2_system = m_system_manager.get_system<mm2_service>();
         return QString::fromStdString(mm2_system.get_current_ticker());
     }
 
     void
-    wallet_page::set_current_ticker(const QString& ticker) 
+    wallet_page::set_current_ticker(const QString& ticker)
     {
         auto& mm2_system = m_system_manager.get_system<mm2_service>();
         if (mm2_system.set_current_ticker(ticker.toStdString()))
@@ -57,13 +57,13 @@ namespace atomic_dex
     }
 
     bool
-    wallet_page::is_rpc_claiming_busy() const 
+    wallet_page::is_rpc_claiming_busy() const
     {
         return m_is_claiming_busy.load();
     }
 
     void
-    wallet_page::set_claiming_is_busy(bool status) 
+    wallet_page::set_claiming_is_busy(bool status)
     {
         if (m_is_claiming_busy != status)
         {
@@ -73,13 +73,13 @@ namespace atomic_dex
     }
 
     bool
-    wallet_page::is_claiming_faucet_busy() const 
+    wallet_page::is_claiming_faucet_busy() const
     {
         return m_is_claiming_faucet_busy.load();
     }
 
     void
-    wallet_page::set_claiming_faucet_is_busy(bool status) 
+    wallet_page::set_claiming_faucet_is_busy(bool status)
     {
         if (m_is_claiming_faucet_busy != status)
         {
@@ -89,7 +89,7 @@ namespace atomic_dex
     }
 
     void
-    wallet_page::set_send_busy(bool status) 
+    wallet_page::set_send_busy(bool status)
     {
         if (m_is_send_busy != status)
         {
@@ -99,19 +99,19 @@ namespace atomic_dex
     }
 
     bool
-    wallet_page::is_send_busy() const 
+    wallet_page::is_send_busy() const
     {
         return m_is_send_busy.load();
     }
 
     bool
-    wallet_page::is_broadcast_busy() const 
+    wallet_page::is_broadcast_busy() const
     {
         return m_is_broadcast_busy.load();
     }
 
     void
-    wallet_page::set_broadcast_busy(bool status) 
+    wallet_page::set_broadcast_busy(bool status)
     {
         if (m_is_broadcast_busy != status)
         {
@@ -121,13 +121,13 @@ namespace atomic_dex
     }
 
     bool
-    atomic_dex::wallet_page::is_tx_fetching_busy() const 
+    atomic_dex::wallet_page::is_tx_fetching_busy() const
     {
         return m_tx_fetching_busy;
     }
 
     void
-    atomic_dex::wallet_page::set_tx_fetching_busy(bool status) 
+    atomic_dex::wallet_page::set_tx_fetching_busy(bool status)
     {
         if (m_tx_fetching_busy != status)
         {
@@ -137,7 +137,7 @@ namespace atomic_dex
     }
 
     QVariant
-    wallet_page::get_ticker_infos() const 
+    wallet_page::get_ticker_infos() const
     {
         // SPDLOG_DEBUG("get_ticker_infos");
         QJsonObject obj{
@@ -196,13 +196,13 @@ namespace atomic_dex
     }
 
     QVariant
-    wallet_page::get_rpc_claiming_data() const 
+    wallet_page::get_rpc_claiming_data() const
     {
         return m_claiming_rpc_result.get();
     }
 
     void
-    wallet_page::set_rpc_claiming_data(QVariant rpc_data) 
+    wallet_page::set_rpc_claiming_data(QVariant rpc_data)
     {
         m_claiming_rpc_result = rpc_data.toJsonObject();
         emit claimingRpcDataChanged();
@@ -210,46 +210,46 @@ namespace atomic_dex
 
 
     QVariant
-    wallet_page::get_rpc_claiming_faucet_data() const 
+    wallet_page::get_rpc_claiming_faucet_data() const
     {
         return m_claiming_rpc_faucet_result.get();
     }
 
     void
-    wallet_page::set_rpc_claiming_faucet_data(QVariant rpc_data) 
+    wallet_page::set_rpc_claiming_faucet_data(QVariant rpc_data)
     {
         m_claiming_rpc_faucet_result = rpc_data.toJsonObject();
         emit claimingFaucetRpcDataChanged();
     }
 
     QString
-    wallet_page::get_rpc_broadcast_data() const 
+    wallet_page::get_rpc_broadcast_data() const
     {
         return m_broadcast_rpc_result.get();
     }
 
     void
-    wallet_page::set_rpc_broadcast_data(QString rpc_data) 
+    wallet_page::set_rpc_broadcast_data(QString rpc_data)
     {
         m_broadcast_rpc_result = rpc_data;
         emit broadcastDataChanged();
     }
 
     QVariant
-    wallet_page::get_rpc_send_data() const 
+    wallet_page::get_rpc_send_data() const
     {
         return m_send_rpc_result.get();
     }
 
     void
-    wallet_page::set_rpc_send_data(QVariant rpc_data) 
+    wallet_page::set_rpc_send_data(QVariant rpc_data)
     {
         m_send_rpc_result = rpc_data.toJsonObject();
         emit sendDataChanged();
     }
 
     bool
-    wallet_page::has_auth_succeeded() const 
+    wallet_page::has_auth_succeeded() const
     {
         return m_auth_succeeded;
     }
@@ -259,7 +259,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     void
-    wallet_page::refresh_ticker_infos() 
+    wallet_page::refresh_ticker_infos()
     {
         // SPDLOG_DEBUG("refresh ticker infos");
         emit tickerInfosChanged();
@@ -361,13 +361,11 @@ namespace atomic_dex
         };
 
         //! Process
-        ::mm2::api::async_rpc_batch_standalone(batch, mm2_system.get_mm2_client(), mm2_system.get_cancellation_token())
-            .then(answer_functor)
-            .then(&handle_exception_pplx_task);
+        mm2_system.get_mm2_client().async_rpc_batch_standalone(batch).then(answer_functor).then(&handle_exception_pplx_task);
     }
 
     void
-    wallet_page::broadcast(const QString& tx_hex, bool is_claiming, bool is_max, const QString& amount) 
+    wallet_page::broadcast(const QString& tx_hex, bool is_claiming, bool is_max, const QString& amount)
     {
 #if defined(__APPLE__) || defined(WIN32)
         QSettings& settings = this->entity_registry_.ctx<QSettings>();
@@ -440,9 +438,7 @@ namespace atomic_dex
             this->set_broadcast_busy(false);
         };
 
-        ::mm2::api::async_rpc_batch_standalone(batch, mm2_system.get_mm2_client(), mm2_system.get_cancellation_token())
-            .then(answer_functor)
-            .then(&handle_exception_pplx_task);
+        mm2_system.get_mm2_client().async_rpc_batch_standalone(batch).then(answer_functor).then(&handle_exception_pplx_task);
     }
 
     void
@@ -458,7 +454,8 @@ namespace atomic_dex
         batch.push_back(json_data);
         json_data = ::mm2::api::template_request("kmd_rewards_info");
         batch.push_back(json_data);
-        ::mm2::api::async_rpc_batch_standalone(batch, mm2_system.get_mm2_client(), mm2_system.get_cancellation_token())
+        mm2_system.get_mm2_client()
+            .async_rpc_batch_standalone(batch)
             .then([this](web::http::http_response resp) {
                 std::string body = TO_STD_STR(resp.extract_string(true).get());
                 // SPDLOG_DEBUG("resp claiming: {}", body);
@@ -504,7 +501,7 @@ namespace atomic_dex
     }
 
     transactions_model*
-    wallet_page::get_transactions_mdl() const 
+    wallet_page::get_transactions_mdl() const
     {
         return m_transactions_mdl;
     }

--- a/src/core/atomicdex/pages/widgets/dex/qt.orders.widget.cpp
+++ b/src/core/atomicdex/pages/widgets/dex/qt.orders.widget.cpp
@@ -28,11 +28,11 @@
 //! Constructor / Destructor
 namespace atomic_dex
 {
-    qt_orders_widget::qt_orders_widget(ag::ecs::system_manager& system_manager, QObject* parent)  : QObject(parent), m_system_mgr(system_manager)
+    qt_orders_widget::qt_orders_widget(ag::ecs::system_manager& system_manager, QObject* parent) : QObject(parent), m_system_mgr(system_manager)
     {
         SPDLOG_INFO("qt_orders_widget created");
     }
-    qt_orders_widget::~qt_orders_widget()  { SPDLOG_INFO("qt_orders widget destroyed"); }
+    qt_orders_widget::~qt_orders_widget() { SPDLOG_INFO("qt_orders widget destroyed"); }
 } // namespace atomic_dex
 
 //! Private member functions
@@ -60,7 +60,8 @@ namespace atomic_dex
 
         batch.push_back(cancel_request);
         auto& mm2_system = m_system_mgr.get_system<mm2_service>();
-        ::mm2::api::async_rpc_batch_standalone(batch, mm2_system.get_mm2_client(), pplx::cancellation_token::none())
+        mm2_system.get_mm2_client()
+            .async_rpc_batch_standalone(batch)
             .then([this]([[maybe_unused]] web::http::http_response resp) {
                 auto& mm2_system = m_system_mgr.get_system<mm2_service>();
                 mm2_system.batch_fetch_orders_and_swap();
@@ -88,7 +89,8 @@ namespace atomic_dex
         }
 
         auto& mm2_system = m_system_mgr.get_system<mm2_service>();
-        ::mm2::api::async_rpc_batch_standalone(batch, mm2_system.get_mm2_client(), pplx::cancellation_token::none())
+        mm2_system.get_mm2_client()
+            .async_rpc_batch_standalone(batch)
             .then([this]([[maybe_unused]] web::http::http_response resp) {
                 auto& mm2_system = m_system_mgr.get_system<mm2_service>();
                 mm2_system.batch_fetch_orders_and_swap();

--- a/src/core/atomicdex/services/exporter/exporter.service.cpp
+++ b/src/core/atomicdex/services/exporter/exporter.service.cpp
@@ -37,7 +37,7 @@ namespace atomic_dex
 namespace atomic_dex
 {
     void
-    exporter_service::update() 
+    exporter_service::update()
     {
     }
 } // namespace atomic_dex
@@ -111,8 +111,6 @@ namespace atomic_dex
             }
         };
 
-        ::mm2::api::async_rpc_batch_standalone(batch, mm2.get_mm2_client(), mm2.get_cancellation_token())
-            .then(answer_functor)
-            .then(&handle_exception_pplx_task);
+        mm2.get_mm2_client().async_rpc_batch_standalone(batch).then(answer_functor).then(&handle_exception_pplx_task);
     }
 } // namespace atomic_dex

--- a/src/core/atomicdex/services/internet/internet.checker.service.cpp
+++ b/src/core/atomicdex/services/internet/internet.checker.service.cpp
@@ -177,7 +177,7 @@ namespace atomic_dex
                 t_orderbook_request req_orderbook{.base = g_primary_dex_coin, .rel = g_second_primary_dex_coin};
                 ::mm2::api::to_json(current_request, req_orderbook);
                 batch.push_back(current_request);
-                auto async_answer = ::mm2::api::async_rpc_batch_standalone(batch, mm2.get_mm2_client(), mm2.get_cancellation_token());
+                auto async_answer = mm2.get_mm2_client().async_rpc_batch_standalone(batch);
                 generic_treat_answer(async_answer, "http://127.0.0.1:7783", &internet_service_checker::is_mm2_endpoint_alive);
             }
             else

--- a/src/core/atomicdex/services/mm2/auto.update.maker.order.service.cpp
+++ b/src/core/atomicdex/services/mm2/auto.update.maker.order.service.cpp
@@ -1,0 +1,119 @@
+/******************************************************************************
+ * Copyright © 2013-2021 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+//! Qt Headers
+#include <QSettings>
+
+// Project Headers
+#include "atomicdex/services/mm2/auto.update.maker.order.service.hpp"
+#include "atomicdex/services/mm2/mm2.service.hpp"
+
+//! Constructor
+namespace atomic_dex
+{
+    auto_update_maker_order_service::auto_update_maker_order_service(entt::registry& registry, ag::ecs::system_manager& system_manager) :
+        system(registry), m_system_manager(system_manager)
+    {
+        m_update_clock = std::chrono::high_resolution_clock::now();
+        SPDLOG_INFO("auto_update_maker_order_service created");
+    }
+} // namespace atomic_dex
+
+//! Private member functions
+namespace atomic_dex
+{
+    void
+    auto_update_maker_order_service::update_order(const t_order_swaps_data& data)
+    {
+        const auto&   mm2               = this->m_system_manager.get_system<mm2_service>();
+        const auto    base_coin_info    = mm2.get_coin_info(data.base_coin.toStdString());
+        const auto    rel_coin_info     = mm2.get_coin_info(data.rel_coin.toStdString());
+        QSettings&    settings          = entity_registry_.ctx<QSettings>();
+        const auto    category_settings = data.base_coin + "_" + data.rel_coin;
+        const QString target_settings   = "Disabled";
+        settings.beginGroup(category_settings);
+        const bool is_disabled = settings.value(target_settings, true).toBool();
+        settings.endGroup();
+        if (base_coin_info.coingecko_id != "test-coin" && rel_coin_info.coingecko_id != "test-coin" && !is_disabled)
+        {
+            SPDLOG_INFO("Updating maker order: {}", data.order_id.toStdString());
+        }
+    }
+
+    void
+    auto_update_maker_order_service::internal_update()
+    {
+        SPDLOG_INFO("update maker orders");
+        const auto&      mm2  = this->m_system_manager.get_system<mm2_service>();
+        orders_and_swaps data = mm2.get_orders_and_swaps();
+        auto             cur  = data.orders_and_swaps.cbegin();
+        auto             end  = data.orders_and_swaps.cbegin() + data.nb_orders;
+        for (; cur != end; ++cur)
+        {
+            if (cur->is_maker)
+            {
+                this->update_order(*cur);
+            }
+        }
+    }
+
+    void
+    auto_update_maker_order_service::process_update_orders()
+    {
+        try
+        {
+            if (this->m_system_manager.has_system<mm2_service>())
+            {
+                const auto& mm2 = this->m_system_manager.get_system<mm2_service>();
+                if (mm2.is_mm2_running())
+                {
+                    this->internal_update();
+                }
+                else
+                {
+                    SPDLOG_WARN("MM2 service is not running yet - skipping");
+                }
+            }
+            else
+            {
+                SPDLOG_WARN("MM2 service not created yet - skipping");
+            }
+        }
+        catch (const std::exception& error)
+        {
+            SPDLOG_ERROR("Exception caught: {}", error.what());
+        }
+    }
+} // namespace atomic_dex
+
+//! Public functions override
+namespace atomic_dex
+{
+    void
+    auto_update_maker_order_service::update()
+    {
+        //! Scan orderbook widget every 30 seconds if there is not any update
+        using namespace std::chrono_literals;
+
+        const auto now = std::chrono::high_resolution_clock::now();
+        const auto s   = std::chrono::duration_cast<std::chrono::seconds>(now - m_update_clock);
+        if (s >= 2min)
+        {
+            process_update_orders();
+            m_update_clock = std::chrono::high_resolution_clock::now();
+        }
+    }
+} // namespace atomic_dex

--- a/src/core/atomicdex/services/mm2/auto.update.maker.order.service.cpp
+++ b/src/core/atomicdex/services/mm2/auto.update.maker.order.service.cpp
@@ -179,4 +179,11 @@ namespace atomic_dex
             m_update_clock = std::chrono::high_resolution_clock::now();
         }
     }
+
+    void
+    auto_update_maker_order_service::force_update()
+    {
+        this->process_update_orders();
+        m_update_clock = std::chrono::high_resolution_clock::now();
+    }
 } // namespace atomic_dex

--- a/src/core/atomicdex/services/mm2/auto.update.maker.order.service.cpp
+++ b/src/core/atomicdex/services/mm2/auto.update.maker.order.service.cpp
@@ -99,13 +99,14 @@ namespace atomic_dex
             ::mm2::api::to_json(setprice_json, request);
             batch.push_back(setprice_json);
             auto& mm2 = this->m_system_manager.get_system<mm2_service>();
-            ::mm2::api::async_rpc_batch_standalone(batch, mm2.get_mm2_client(), pplx::cancellation_token::none())
+            mm2.get_mm2_client()
+                .async_rpc_batch_standalone(batch)
                 .then([this]([[maybe_unused]] web::http::http_response resp) {
                     std::string body = TO_STD_STR(resp.extract_string(true).get());
                     if (resp.status_code() == 200)
                     {
-                        //auto& mm2_system = m_system_manager.get_system<mm2_service>();
-                        //mm2_system.batch_fetch_orders_and_swap();
+                        // auto& mm2_system = m_system_manager.get_system<mm2_service>();
+                        // mm2_system.batch_fetch_orders_and_swap();
                     }
                     else
                     {

--- a/src/core/atomicdex/services/mm2/auto.update.maker.order.service.cpp
+++ b/src/core/atomicdex/services/mm2/auto.update.maker.order.service.cpp
@@ -183,7 +183,7 @@ namespace atomic_dex
     void
     auto_update_maker_order_service::force_update()
     {
-        //this->process_update_orders();
-        //m_update_clock = std::chrono::high_resolution_clock::now();
+        this->process_update_orders();
+        m_update_clock = std::chrono::high_resolution_clock::now();
     }
 } // namespace atomic_dex

--- a/src/core/atomicdex/services/mm2/auto.update.maker.order.service.cpp
+++ b/src/core/atomicdex/services/mm2/auto.update.maker.order.service.cpp
@@ -183,7 +183,7 @@ namespace atomic_dex
     void
     auto_update_maker_order_service::force_update()
     {
-        this->process_update_orders();
-        m_update_clock = std::chrono::high_resolution_clock::now();
+        //this->process_update_orders();
+        //m_update_clock = std::chrono::high_resolution_clock::now();
     }
 } // namespace atomic_dex

--- a/src/core/atomicdex/services/mm2/auto.update.maker.order.service.cpp
+++ b/src/core/atomicdex/services/mm2/auto.update.maker.order.service.cpp
@@ -104,8 +104,8 @@ namespace atomic_dex
                     std::string body = TO_STD_STR(resp.extract_string(true).get());
                     if (resp.status_code() == 200)
                     {
-                        auto& mm2_system = m_system_manager.get_system<mm2_service>();
-                        mm2_system.batch_fetch_orders_and_swap();
+                        //auto& mm2_system = m_system_manager.get_system<mm2_service>();
+                        //mm2_system.batch_fetch_orders_and_swap();
                     }
                     else
                     {

--- a/src/core/atomicdex/services/mm2/auto.update.maker.order.service.hpp
+++ b/src/core/atomicdex/services/mm2/auto.update.maker.order.service.hpp
@@ -23,6 +23,7 @@
 
 //! Project Headers
 #include "atomicdex/data/dex/qt.orders.data.hpp"
+#include "atomicdex/utilities/safe.float.hpp"
 
 //! Namespace declaration
 namespace atomic_dex
@@ -38,9 +39,10 @@ namespace atomic_dex
         t_update_time_point      m_update_clock;
 
         //! Private member functions
-        void process_update_orders();
-        void internal_update();
-        void update_order(const t_order_swaps_data& data);
+        void        process_update_orders();
+        void        internal_update();
+        void        update_order(const t_order_swaps_data& data);
+        std::string get_new_price_from_order(const t_order_swaps_data& data, const t_float_50& spread);
 
       public:
         //! Constructor

--- a/src/core/atomicdex/services/mm2/auto.update.maker.order.service.hpp
+++ b/src/core/atomicdex/services/mm2/auto.update.maker.order.service.hpp
@@ -1,0 +1,57 @@
+/******************************************************************************
+ * Copyright © 2013-2021 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+#pragma once
+
+//! Deps
+#include <antara/gaming/ecs/system.manager.hpp>
+#include <boost/thread/synchronized_value.hpp>
+#include <nlohmann/json.hpp>
+
+//! Project Headers
+#include "atomicdex/data/dex/qt.orders.data.hpp"
+
+//! Namespace declaration
+namespace atomic_dex
+{
+    //! Class declaration
+    class auto_update_maker_order_service final : public ag::ecs::pre_update_system<auto_update_maker_order_service>
+    {
+        //! Private typedefs
+        using t_update_time_point = std::chrono::high_resolution_clock::time_point;
+
+        //! Private member fields
+        ag::ecs::system_manager& m_system_manager;
+        t_update_time_point      m_update_clock;
+
+        //! Private member functions
+        void process_update_orders();
+        void internal_update();
+        void update_order(const t_order_swaps_data& data);
+
+      public:
+        //! Constructor
+        explicit auto_update_maker_order_service(entt::registry& registry, ag::ecs::system_manager& system_manager);
+
+        //! Destructor
+        ~auto_update_maker_order_service() final = default;
+
+        //! Public override
+        void update() final;
+    };
+} // namespace atomic_dex
+
+REFL_AUTO(type(atomic_dex::auto_update_maker_order_service))

--- a/src/core/atomicdex/services/mm2/auto.update.maker.order.service.hpp
+++ b/src/core/atomicdex/services/mm2/auto.update.maker.order.service.hpp
@@ -53,6 +53,8 @@ namespace atomic_dex
 
         //! Public override
         void update() final;
+
+        void force_update();
     };
 } // namespace atomic_dex
 

--- a/src/core/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.cpp
@@ -123,7 +123,7 @@ namespace
 namespace atomic_dex
 {
     std::vector<atomic_dex::coin_config>
-    mm2_service::retrieve_coins_informations() 
+    mm2_service::retrieve_coins_informations()
     {
         std::vector<atomic_dex::coin_config> cfg;
         SPDLOG_DEBUG("{} l{} f[{}]", __FUNCTION__, __LINE__, fs::path(__FILE__).filename().string());
@@ -162,7 +162,7 @@ namespace atomic_dex
     }
 
     void
-    mm2_service::update() 
+    mm2_service::update()
     {
         using namespace std::chrono_literals;
 
@@ -189,7 +189,7 @@ namespace atomic_dex
         }
     }
 
-    mm2_service::~mm2_service() 
+    mm2_service::~mm2_service()
     {
         SPDLOG_INFO("destroying mm2 service...");
         dispatcher_.sink<gui_enter_trading>().disconnect<&mm2_service::on_gui_enter_trading>(*this);
@@ -204,7 +204,7 @@ namespace atomic_dex
             nlohmann::json batch        = nlohmann::json::array();
             batch.push_back(stop_request);
             SPDLOG_INFO("processing mm2 stop batch request");
-            pplx::task<web::http::http_response> resp_task = ::mm2::api::async_rpc_batch_standalone(batch, m_mm2_client, m_token_source.get_token());
+            pplx::task<web::http::http_response> resp_task = m_mm2_client.async_rpc_batch_standalone(batch);
             web::http::http_response             resp      = resp_task.get();
             SPDLOG_INFO("mm2 stop batch answer received");
             auto answers = ::mm2::api::basic_batch_answer(resp);
@@ -215,7 +215,8 @@ namespace atomic_dex
             }
         }
         m_mm2_running = false;
-        m_token_source.cancel();
+        // m_token_source.cancel();
+        m_mm2_client.stop();
 
         if (!mm2_stopped)
         {
@@ -247,13 +248,13 @@ namespace atomic_dex
     }
 
     const std::atomic_bool&
-    mm2_service::is_mm2_running() const 
+    mm2_service::is_mm2_running() const
     {
         return m_mm2_running;
     }
 
     t_coins
-    mm2_service::get_enabled_coins() const 
+    mm2_service::get_enabled_coins() const
     {
         t_coins destination;
 
@@ -270,7 +271,7 @@ namespace atomic_dex
     }
 
     t_coins
-    mm2_service::get_active_coins() const 
+    mm2_service::get_active_coins() const
     {
         t_coins destination;
 
@@ -287,7 +288,7 @@ namespace atomic_dex
     }
 
     bool
-    mm2_service::disable_coin(const std::string& ticker, std::error_code& ec) 
+    mm2_service::disable_coin(const std::string& ticker, std::error_code& ec)
     {
         coin_config coin_info = get_coin_info(ticker);
         if (not coin_info.currently_enabled)
@@ -296,7 +297,7 @@ namespace atomic_dex
         }
 
         t_disable_coin_request request{.coin = ticker};
-        auto                   answer = rpc_disable_coin(std::move(request), m_mm2_client);
+        auto                   answer = m_mm2_client.rpc_disable_coin(std::move(request));
 
         if (answer.error.has_value())
         {
@@ -330,7 +331,7 @@ namespace atomic_dex
     }
 
     bool
-    mm2_service::enable_default_coins() 
+    mm2_service::enable_default_coins()
     {
         std::atomic<std::size_t> result{1};
         auto                     coins = get_active_coins();
@@ -347,7 +348,7 @@ namespace atomic_dex
     }
 
     void
-    mm2_service::disable_multiple_coins(const std::vector<std::string>& tickers) 
+    mm2_service::disable_multiple_coins(const std::vector<std::string>& tickers)
     {
         SPDLOG_DEBUG("{} l{} f[{}]", __FUNCTION__, __LINE__, fs::path(__FILE__).filename().string());
         for (const auto& ticker: tickers)
@@ -368,7 +369,7 @@ namespace atomic_dex
     {
         SPDLOG_INFO("batch_balance_and_tx");
         auto&& [batch_array, tickers_idx, tokens_to_fetch] = prepare_batch_balance_and_tx(only_tx);
-        return ::mm2::api::async_rpc_batch_standalone(batch_array, m_mm2_client, m_token_source.get_token())
+        return m_mm2_client.async_rpc_batch_standalone(batch_array)
             .then([this, tickers_idx = tickers_idx, tokens_to_fetch = tokens_to_fetch, is_a_reset, tickers, is_during_enabling](web::http::http_response resp) {
                 try
                 {
@@ -482,7 +483,7 @@ namespace atomic_dex
     }
 
     void
-    mm2_service::batch_enable_coins(const std::vector<std::string>& tickers, bool first_time) 
+    mm2_service::batch_enable_coins(const std::vector<std::string>& tickers, bool first_time)
     {
         nlohmann::json btc_kmd_batch = nlohmann::json::array();
         if (first_time)
@@ -555,7 +556,7 @@ namespace atomic_dex
 
         // SPDLOG_DEBUG("{}", batch_array.dump(4));
         auto functor = [this](nlohmann::json batch_array, std::vector<std::string> tickers) {
-            ::mm2::api::async_rpc_batch_standalone(batch_array, this->m_mm2_client, m_token_source.get_token())
+            m_mm2_client.async_rpc_batch_standalone(batch_array)
                 .then([this, tickers](web::http::http_response resp) mutable {
                     try
                     {
@@ -616,7 +617,7 @@ namespace atomic_dex
     }
 
     void
-    mm2_service::enable_multiple_coins(const std::vector<std::string>& tickers) 
+    mm2_service::enable_multiple_coins(const std::vector<std::string>& tickers)
     {
         batch_enable_coins(tickers);
         update_coin_status(this->m_current_wallet_name, tickers, true);
@@ -634,7 +635,7 @@ namespace atomic_dex
     }
 
     t_orderbook_answer
-    mm2_service::get_orderbook(t_mm2_ec& ec) const 
+    mm2_service::get_orderbook(t_mm2_ec& ec) const
     {
         auto&& [base, rel]          = this->m_synchronized_ticker_pair.get();
         const std::string pair      = base + "/" + rel;
@@ -694,7 +695,7 @@ namespace atomic_dex
         }
         auto&& [orderbook_ticker_base, orderbook_ticker_rel] = m_synchronized_ticker_pair.get();
 
-        ::mm2::api::async_rpc_batch_standalone(batch, m_mm2_client, m_token_source.get_token())
+        m_mm2_client.async_rpc_batch_standalone(batch)
             .then(
                 [this, orderbook_ticker_base = orderbook_ticker_base, orderbook_ticker_rel = orderbook_ticker_rel, is_a_reset](web::http::http_response resp) {
                     auto answer = ::mm2::api::basic_batch_answer(resp);
@@ -749,7 +750,7 @@ namespace atomic_dex
             return;
         auto&& [base, rel] = m_synchronized_ticker_pair.get();
 
-        ::mm2::api::async_rpc_batch_standalone(batch, m_mm2_client, m_token_source.get_token())
+        m_mm2_client.async_rpc_batch_standalone(batch)
             .then([this, is_a_reset, base = base, rel = rel](web::http::http_response resp) {
                 auto answer = ::mm2::api::basic_batch_answer(resp);
                 if (answer.is_array())
@@ -866,10 +867,7 @@ namespace atomic_dex
                 std::this_thread::sleep_for(1s);
             }
 
-            web::http::client::http_client_config cfg;
-            using namespace std::chrono_literals;
-            cfg.set_timeout(30s);
-            m_mm2_client = std::make_shared<web::http::client::http_client>(FROM_STD_STR(::mm2::api::g_endpoint), cfg);
+            //m_mm2_client.connect_client();
             fs::remove(mm2_cfg_path);
             SPDLOG_INFO("mm2 is initialized");
             dispatcher_.trigger<mm2_initialized>();
@@ -888,13 +886,14 @@ namespace atomic_dex
     }
 
     std::pair<t_transactions, t_tx_state>
-    mm2_service::get_tx(t_mm2_ec& ec) const 
+    mm2_service::get_tx(t_mm2_ec& ec) const
     {
         const auto& ticker = get_current_ticker();
         // SPDLOG_DEBUG("asking history of ticker: {}", ticker);
         const auto underlying_tx_history_map = m_tx_informations.synchronize();
         const auto coin_type                 = get_coin_info(ticker).coin_type;
-        const auto it = !(coin_type == CoinType::ERC20 || coin_type == CoinType::BEP20) ? underlying_tx_history_map->find("result") : underlying_tx_history_map->find(ticker);
+        const auto it                        = !(coin_type == CoinType::ERC20 || coin_type == CoinType::BEP20) ? underlying_tx_history_map->find("result")
+                                                                                                               : underlying_tx_history_map->find(ticker);
         if (it == underlying_tx_history_map->cend())
         {
             ec = dextop_error::tx_history_of_a_non_enabled_coin;
@@ -1036,9 +1035,9 @@ namespace atomic_dex
             this->dispatcher_.trigger<process_swaps_and_orders_finished>(after_manual_reset);
         };
 
-        ::mm2::api::async_rpc_batch_standalone(batch, m_mm2_client, m_token_source.get_token())
-            .then(answer_functor)
-            .then([this](pplx::task<void> previous_task) { this->handle_exception_pplx_task(previous_task); });
+        m_mm2_client.async_rpc_batch_standalone(batch).then(answer_functor).then([this](pplx::task<void> previous_task) {
+            this->handle_exception_pplx_task(previous_task, "batch_fetch_orders_and_swap");
+        });
     }
 
     void
@@ -1048,19 +1047,19 @@ namespace atomic_dex
         std::error_code ec;
         using namespace std::string_literals;
         auto retrieve_api_functor = [this](const std::string& ticker, const std::string& address) -> std::string {
-            const auto coin_info = this->get_coin_info(ticker);
+            const auto  coin_info = this->get_coin_info(ticker);
             std::string out;
             switch (coin_info.coin_type)
             {
             case CoinTypeGadget::ERC20:
                 if (ticker == "ETH" || ticker == "ETHR")
                 {
-                    out =  "/api/v1/eth_tx_history/" + address;
+                    out = "/api/v1/eth_tx_history/" + address;
                 }
                 else
                 {
                     const std::string contract_address = get_raw_mm2_ticker_cfg(ticker).at("protocol").at("protocol_data").at("contract_address");
-                    out = "/api/v2/erc_tx_history/" + contract_address + "/" + address;
+                    out                                = "/api/v2/erc_tx_history/" + contract_address + "/" + address;
                 }
                 break;
             case CoinTypeGadget::BEP20:
@@ -1071,7 +1070,7 @@ namespace atomic_dex
                 else
                 {
                     const std::string contract_address = get_raw_mm2_ticker_cfg(ticker).at("protocol").at("protocol_data").at("contract_address");
-                    out = "/api/v2/bep_tx_history/" + contract_address + "/" + address;
+                    out                                = "/api/v2/bep_tx_history/" + contract_address + "/" + address;
                 }
             default:
                 break;
@@ -1085,7 +1084,7 @@ namespace atomic_dex
         std::string url = retrieve_api_functor(ticker, address(ticker, ec));
         ::mm2::api::async_process_rpc_get(::mm2::api::g_etherscan_proxy_http_client, "tx_history", url)
             .then([this, ticker](web::http::http_response resp) {
-                auto answer = ::mm2::api::rpc_process_answer<::mm2::api::tx_history_answer>(resp, "tx_history");
+                auto answer = m_mm2_client.rpc_process_answer<::mm2::api::tx_history_answer>(resp, "tx_history");
 
                 if (answer.rpc_result_code != 200)
                 {
@@ -1164,7 +1163,7 @@ namespace atomic_dex
     }
 
     void
-    mm2_service::on_gui_enter_trading([[maybe_unused]] const gui_enter_trading& evt) 
+    mm2_service::on_gui_enter_trading([[maybe_unused]] const gui_enter_trading& evt)
     {
         SPDLOG_DEBUG("{} l{} f[{}]", __FUNCTION__, __LINE__, fs::path(__FILE__).filename().string());
 
@@ -1172,7 +1171,7 @@ namespace atomic_dex
     }
 
     void
-    mm2_service::on_gui_leave_trading([[maybe_unused]] const gui_leave_trading& evt) 
+    mm2_service::on_gui_leave_trading([[maybe_unused]] const gui_leave_trading& evt)
     {
         SPDLOG_DEBUG("{} l{} f[{}]", __FUNCTION__, __LINE__, fs::path(__FILE__).filename().string());
         m_orderbook_thread_active = false;
@@ -1186,7 +1185,7 @@ namespace atomic_dex
     }
 
     std::string
-    mm2_service::address(const std::string& ticker, t_mm2_ec& ec) const 
+    mm2_service::address(const std::string& ticker, t_mm2_ec& ec) const
     {
         std::shared_lock lock(m_balance_mutex);
         auto             it = m_balance_informations.find(ticker);
@@ -1247,13 +1246,13 @@ namespace atomic_dex
     }
 
     bool
-    mm2_service::is_orderbook_thread_active() const 
+    mm2_service::is_orderbook_thread_active() const
     {
         return this->m_orderbook_thread_active.load();
     }
 
     nlohmann::json
-    mm2_service::get_raw_mm2_ticker_cfg(const std::string& ticker) const 
+    mm2_service::get_raw_mm2_ticker_cfg(const std::string& ticker) const
     {
         nlohmann::json out;
 
@@ -1269,19 +1268,19 @@ namespace atomic_dex
     }
 
     mm2_service::t_pair_max_vol
-    mm2_service::get_taker_vol() const 
+    mm2_service::get_taker_vol() const
     {
         return m_synchronized_max_taker_vol.get();
     }
 
     bool
-    mm2_service::is_pin_cfg_enabled() const 
+    mm2_service::is_pin_cfg_enabled() const
     {
         return m_balance_factor != 1.0;
     }
 
     void
-    mm2_service::reset_fake_balance_to_zero(const std::string& ticker) 
+    mm2_service::reset_fake_balance_to_zero(const std::string& ticker)
     {
         {
             std::unique_lock lock(m_balance_mutex);
@@ -1291,7 +1290,7 @@ namespace atomic_dex
     }
 
     void
-    mm2_service::decrease_fake_balance(const std::string& ticker, const std::string& amount) 
+    mm2_service::decrease_fake_balance(const std::string& ticker, const std::string& amount)
     {
         t_float_50 balance = get_balance(ticker);
         t_float_50 amount_f(amount);
@@ -1449,20 +1448,20 @@ namespace atomic_dex
         //this->dispatcher_.trigger<process_orders_finished>();
     }*/
 
-    std::shared_ptr<t_http_client>
-    mm2_service::get_mm2_client() 
+    mm2_client&
+    mm2_service::get_mm2_client()
     {
         return m_mm2_client;
     }
 
     std::string
-    mm2_service::get_current_ticker() const 
+    mm2_service::get_current_ticker() const
     {
         return m_current_ticker.get();
     }
 
     bool
-    mm2_service::set_current_ticker(const std::string& ticker) 
+    mm2_service::set_current_ticker(const std::string& ticker)
     {
         if (ticker != get_current_ticker())
         {
@@ -1472,14 +1471,14 @@ namespace atomic_dex
         return false;
     }
 
-    pplx::cancellation_token
-    mm2_service::get_cancellation_token() const 
+    /*pplx::cancellation_token
+    mm2_service::get_cancellation_token() const
     {
         return m_token_source.get_token();
-    }
+    }*/
 
     void
-    mm2_service::add_new_coin(const nlohmann::json& coin_cfg_json, const nlohmann::json& raw_coin_cfg_json) 
+    mm2_service::add_new_coin(const nlohmann::json& coin_cfg_json, const nlohmann::json& raw_coin_cfg_json)
     {
         //! Normal cfg part
         SPDLOG_DEBUG("[{}], [{}]", coin_cfg_json.dump(4), raw_coin_cfg_json.dump(4));
@@ -1531,21 +1530,21 @@ namespace atomic_dex
     }
 
     bool
-    mm2_service::is_this_ticker_present_in_raw_cfg(const std::string& ticker) const 
+    mm2_service::is_this_ticker_present_in_raw_cfg(const std::string& ticker) const
     {
         std::shared_lock lock(m_raw_coin_cfg_mutex);
         return m_mm2_raw_coins_cfg.find(ticker) != m_mm2_raw_coins_cfg.end();
     }
 
     bool
-    mm2_service::is_this_ticker_present_in_normal_cfg(const std::string& ticker) const 
+    mm2_service::is_this_ticker_present_in_normal_cfg(const std::string& ticker) const
     {
         std::shared_lock lock(m_coin_cfg_mutex);
         return m_coins_informations.find(ticker) != m_coins_informations.end();
     }
 
     void
-    mm2_service::remove_custom_coin(const std::string& ticker) 
+    mm2_service::remove_custom_coin(const std::string& ticker)
     {
         //! Coin need to be disabled to be removed
         assert(not get_coin_info(ticker).currently_enabled);
@@ -1605,7 +1604,7 @@ namespace atomic_dex
     }
 
     void
-    mm2_service::add_get_trade_fee_answer(const std::string& ticker, t_get_trade_fee_answer answer) 
+    mm2_service::add_get_trade_fee_answer(const std::string& ticker, t_get_trade_fee_answer answer)
     {
         this->m_trade_fees_registry->operator[](ticker) = answer;
     }
@@ -1632,7 +1631,7 @@ namespace atomic_dex
     }
 
     orders_and_swaps
-    mm2_service::get_orders_and_swaps() const 
+    mm2_service::get_orders_and_swaps() const
     {
         return m_orders_and_swaps.get();
     }

--- a/src/core/atomicdex/services/mm2/mm2.service.hpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.hpp
@@ -16,6 +16,9 @@
 
 #pragma once
 
+//! Qt
+#include <QNetworkAccessManager>
+
 #include <shared_mutex>
 #include <thread>
 #include <unordered_set>
@@ -28,6 +31,7 @@
 #include <reproc++/reproc.hpp>
 
 //! Project Headers
+#include "atomicdex/api/mm2/mm2.client.hpp"
 #include "atomicdex/api/mm2/mm2.constants.hpp"
 #include "atomicdex/api/mm2/mm2.error.code.hpp"
 #include "atomicdex/api/mm2/mm2.hpp"
@@ -75,9 +79,12 @@ namespace atomic_dex
         using t_synchronized_ticker        = boost::synchronized_value<std::string>;
 
         ag::ecs::system_manager& m_system_manager;
+
         //! Client
-        std::shared_ptr<t_http_client>  m_mm2_client{nullptr};
-        pplx::cancellation_token_source m_token_source;
+        // std::shared_ptr<t_http_client>  m_mm2_client{nullptr};
+        // pplx::cancellation_token_source m_token_source;
+        mm2_client m_mm2_client;
+
         //! Process
         reproc::process m_mm2_instance;
 
@@ -133,9 +140,9 @@ namespace atomic_dex
 
         //!
         std::pair<bool, std::string>                        process_batch_enable_answer(const nlohmann::json& answer);
-        [[nodiscard]] std::pair<t_transactions, t_tx_state> get_tx(t_mm2_ec& ec) const ;
+        [[nodiscard]] std::pair<t_transactions, t_tx_state> get_tx(t_mm2_ec& ec) const;
         std::vector<electrum_server>                        get_electrum_server_from_token(const std::string& ticker);
-        std::vector<atomic_dex::coin_config>                retrieve_coins_informations() ;
+        std::vector<atomic_dex::coin_config>                retrieve_coins_informations();
 
         void handle_exception_pplx_task(pplx::task<void> previous_task, const std::string& from = "");
 
@@ -150,14 +157,14 @@ namespace atomic_dex
         mm2_service& operator=(const mm2_service&& other) = delete;
 
         //! Destructor
-        ~mm2_service()  final;
+        ~mm2_service() final;
 
         //! Events
         void on_refresh_orderbook(const orderbook_refresh& evt);
 
-        void on_gui_enter_trading(const gui_enter_trading& evt) ;
+        void on_gui_enter_trading(const gui_enter_trading& evt);
 
-        void on_gui_leave_trading(const gui_leave_trading& evt) ;
+        void on_gui_leave_trading(const gui_leave_trading& evt);
 
         //! Spawn mm2 instance with given seed
         void spawn_mm2_instance(std::string wallet_name, std::string passphrase, bool with_pin_cfg = false);
@@ -166,34 +173,34 @@ namespace atomic_dex
         void fetch_infos_thread(bool is_a_fresh = true, bool only_tx = false);
 
         //! Enable coins
-        bool enable_default_coins() ;
+        bool enable_default_coins();
 
         //! Batch Enable coins
-        void batch_enable_coins(const std::vector<std::string>& tickers, bool first_time = false) ;
+        void batch_enable_coins(const std::vector<std::string>& tickers, bool first_time = false);
 
         //! Enable multiple coins
-        void enable_multiple_coins(const std::vector<std::string>& tickers) ;
+        void enable_multiple_coins(const std::vector<std::string>& tickers);
 
         //! Add a new coin in the coin_info cfg add_new_coin(normal_cfg, mm2_cfg)
-        void               add_new_coin(const nlohmann::json& coin_cfg_json, const nlohmann::json& raw_coin_cfg_json) ;
-        void               remove_custom_coin(const std::string& ticker) ;
-        [[nodiscard]] bool is_this_ticker_present_in_raw_cfg(const std::string& ticker) const ;
-        [[nodiscard]] bool is_this_ticker_present_in_normal_cfg(const std::string& ticker) const ;
+        void               add_new_coin(const nlohmann::json& coin_cfg_json, const nlohmann::json& raw_coin_cfg_json);
+        void               remove_custom_coin(const std::string& ticker);
+        [[nodiscard]] bool is_this_ticker_present_in_raw_cfg(const std::string& ticker) const;
+        [[nodiscard]] bool is_this_ticker_present_in_normal_cfg(const std::string& ticker) const;
 
         //! Disable a single coin
-        bool disable_coin(const std::string& ticker, std::error_code& ec) ;
+        bool disable_coin(const std::string& ticker, std::error_code& ec);
 
         //! Disable multiple coins, prefer this function if you want persistent disabling
-        void disable_multiple_coins(const std::vector<std::string>& tickers) ;
+        void disable_multiple_coins(const std::vector<std::string>& tickers);
 
         //! Called every ticks, and execute tasks if the timer expire.
-        void update()  final;
+        void update() final;
 
         //! Retrieve public address of the given ticker
-        std::string address(const std::string& ticker, t_mm2_ec& ec) const ;
+        std::string address(const std::string& ticker, t_mm2_ec& ec) const;
 
         //! Is MM2 Process correctly running ?
-        [[nodiscard]] const std::atomic_bool& is_mm2_running() const ;
+        [[nodiscard]] const std::atomic_bool& is_mm2_running() const;
 
         //! Retrieve my balance for a given ticker as a string.
         [[nodiscard]] std::string my_balance(const std::string& ticker, t_mm2_ec& ec) const;
@@ -210,10 +217,10 @@ namespace atomic_dex
         [[nodiscard]] t_tx_state get_tx_state(t_mm2_ec& ec) const;
 
         //! Get coins that are currently enabled
-        [[nodiscard]] t_coins get_enabled_coins() const ;
+        [[nodiscard]] t_coins get_enabled_coins() const;
 
         //! Get coins that are active, but may be not enabled
-        [[nodiscard]] t_coins get_active_coins() const ;
+        [[nodiscard]] t_coins get_active_coins() const;
 
         //! Get Specific info about one coin
         [[nodiscard]] coin_config get_coin_info(const std::string& ticker) const;
@@ -225,10 +232,10 @@ namespace atomic_dex
         std::string apply_specific_fees(const std::string& ticker, t_float_50& value) const;
 
         //! Get Current orderbook
-        [[nodiscard]] t_orderbook_answer get_orderbook(t_mm2_ec& ec) const ;
+        [[nodiscard]] t_orderbook_answer get_orderbook(t_mm2_ec& ec) const;
 
         //! Get Swaps
-        [[nodiscard]] orders_and_swaps get_orders_and_swaps() const ;
+        [[nodiscard]] orders_and_swaps get_orders_and_swaps() const;
 
         //! Get balance with locked funds for a given ticker as a boost::multiprecision::cpp_dec_float_50.
         [[nodiscard]] t_float_50 get_balance(const std::string& ticker) const;
@@ -236,29 +243,29 @@ namespace atomic_dex
         //! Return true if we the balance of the `ticker` > amount, false otherwise.
         [[nodiscard]] bool do_i_have_enough_funds(const std::string& ticker, const t_float_50& amount) const;
 
-        [[nodiscard]] bool is_orderbook_thread_active() const ;
+        [[nodiscard]] bool is_orderbook_thread_active() const;
 
-        [[nodiscard]] nlohmann::json get_raw_mm2_ticker_cfg(const std::string& ticker) const ;
+        [[nodiscard]] nlohmann::json get_raw_mm2_ticker_cfg(const std::string& ticker) const;
 
-        [[nodiscard]] t_pair_max_vol get_taker_vol() const ;
+        [[nodiscard]] t_pair_max_vol get_taker_vol() const;
 
         //! Pin cfg api
-        [[nodiscard]] bool is_pin_cfg_enabled() const ;
-        void               reset_fake_balance_to_zero(const std::string& ticker) ;
-        void               decrease_fake_balance(const std::string& ticker, const std::string& amount) ;
+        [[nodiscard]] bool is_pin_cfg_enabled() const;
+        void               reset_fake_balance_to_zero(const std::string& ticker);
+        void               decrease_fake_balance(const std::string& ticker, const std::string& amount);
         void               batch_fetch_orders_and_swap(bool after_manual_reset = false);
         void               add_orders_answer(t_my_orders_answer answer);
 
         //! Async API
-        std::shared_ptr<t_http_client>         get_mm2_client() ;
-        [[nodiscard]] pplx::cancellation_token get_cancellation_token() const ;
+        mm2_client&                            get_mm2_client();
+        //[[nodiscard]] pplx::cancellation_token get_cancellation_token() const;
 
         //! Wallet api
-        [[nodiscard]] std::string get_current_ticker() const ;
-        bool                      set_current_ticker(const std::string& ticker) ;
+        [[nodiscard]] std::string get_current_ticker() const;
+        bool                      set_current_ticker(const std::string& ticker);
 
         //! Multi ticker
-        void add_get_trade_fee_answer(const std::string& ticker, t_get_trade_fee_answer answer) ;
+        void add_get_trade_fee_answer(const std::string& ticker, t_get_trade_fee_answer answer);
 
         //! Pagination
         void set_orders_and_swaps_pagination_infos(std::size_t current_page = 1, std::size_t limit = 50, t_filtering_infos infos = {});

--- a/src/core/atomicdex/services/price/orderbook.scanner.service.cpp
+++ b/src/core/atomicdex/services/price/orderbook.scanner.service.cpp
@@ -75,7 +75,7 @@ namespace atomic_dex
                     this->dispatcher_.trigger<process_orderbook_finished>(false);
                 };
 
-                ::mm2::api::async_rpc_batch_standalone(batch, mm2_system.get_mm2_client(), mm2_system.get_cancellation_token())
+                mm2_system.get_mm2_client().async_rpc_batch_standalone(batch)
                     .then(answer_functor)
                     .then([this](pplx::task<void> previous_task) {
                         try

--- a/src/core/atomicdex/utilities/nlohmann.json.sax.private.cpp
+++ b/src/core/atomicdex/utilities/nlohmann.json.sax.private.cpp
@@ -18,7 +18,7 @@
 
 namespace atomic_dex::utils::details
 {
-    struct my_json_sax : nlohmann::json_sax<nlohmann::json>
+    /*struct my_json_sax : nlohmann::json_sax<nlohmann::json>
     {
         bool binary([[maybe_unused]] binary_t& val) override;
 
@@ -130,5 +130,5 @@ namespace atomic_dex::utils::details
         [[maybe_unused]] std::size_t position, [[maybe_unused]] const std::string& last_token, [[maybe_unused]] const nlohmann::detail::exception& ex)
     {
         return false;
-    }
+    }*/
 } // namespace atomic_dex::utils::details

--- a/src/tests/api/mm2/mm2.rpc.trade.preimage.tests.cpp
+++ b/src/tests/api/mm2/mm2.rpc.trade.preimage.tests.cpp
@@ -343,7 +343,7 @@ SCENARIO("mm2::api::preimage scenario")
     //! Generic resp functor that will be used in every tests
     auto generic_resp_process = [&mm2, &batch]() {
         //! Process the actual request
-        const auto resp = ::mm2::api::async_rpc_batch_standalone(batch, mm2.get_mm2_client(), mm2.get_cancellation_token()).get();
+        const auto resp = mm2.get_mm2_client().async_rpc_batch_standalone(batch).get();
 
         //! Retrieve the body
         std::string body = TO_STD_STR(resp.extract_string(true).get());

--- a/src/tests/atomic.dex.tests.hpp
+++ b/src/tests/atomic.dex.tests.hpp
@@ -14,6 +14,8 @@
  *                                                                            *
  ******************************************************************************/
 
+#pragma once
+
 //! Deps
 #include <antara/gaming/world/world.app.hpp>
 


### PR DESCRIPTION
In your AppData folder you have a cfg named `cfg.ini`, eg on osx: `/Users/milerius/.atomic_qt/0.4.0/configs/cfg.ini`

In this file you can setup the following configuration:

```
➜  configs cat cfg.ini 
[General]
AutomaticUpdateOrderBot=true
CurrentTheme=Dark.json
FontMode=1
SecondSecuritySending=false
ThemePath=/Users/milerius/.atomic_qt/themes

[BUSD-BEP20_KMD]
Disabled=false
Spread=2.5

[KMD_BUSD-BEP20]
Disabled=false
Spread=2.5
```

You can set configuration for each pair and the desired spread, it's will automatically update your maker order every 2 minutes based on CEX rates returned by coingecko, all test-coin and coin that don't have a CEX rate will be ignored.

This is a first step to avoid updating your orders yourself and following the market price without getting fooled.

Notes:
- You cannot choose the provider, it's only coingecko for the moment.
- The initial created order will not follow the settings, and will wait 2 min before being updated based on your `cfg.ini` configuration
- There is no GUI part (yet)
- You cannot choose the delay between each update, it's 2min because `coingecko` update their rates every 2min.
- Underscore is the separator for the pair: `BASE_REL`  - `/` is not supported by INI files in categories. `-` is already used for our type specification regarding `ERC20` and `BEP20`
- You need to have the field `AutomaticUpdateOrderBot` set to true in `cfg.ini` if you want to use the bot, it's false by default.
- Enabling the bot can only be done manually in the `cfg.ini` atm.
- Resetting your configuration will reset your `cfg.ini` to default and delete all your settings for trading. 
- When you enter to the dex page, and if your bot is enabled in the cfg, then all your maker order will automatically be updated

If you have any question about the usage, please ping me.