### PR TITLE
Add Window flag to DexWindow

### DIFF
--- a/atomic_defi_design/qml/Components/DexWindow.qml
+++ b/atomic_defi_design/qml/Components/DexWindow.qml
@@ -8,5 +8,5 @@ import "../Constants"
 
 ApplicationWindow {
     id: window
-    flags: Qt.FramelessWindowHint
+    flags: Qt.FramelessWindowHint | Qt.Window
 }


### PR DESCRIPTION
Checklist:

Tested on windows and the last commit correct the taskbar icon visibility problem.

1. `Open application folder in File Explorer`
2. `Double click atomicdex-desktop.exe to launch app`
3. `After app start, check Windows taskbar`