### PR TITLE
feat(best_orders): exclude best orders that are more than 100% diff with cex prices

### DIFF
--- a/src/core/atomicdex/models/qt.orderbook.proxy.model.cpp
+++ b/src/core/atomicdex/models/qt.orderbook.proxy.model.cpp
@@ -107,7 +107,7 @@ namespace atomic_dex
                 break;
             case orderbook_model::kind::best_orders:
                 t_float_50 rates = safe_float(this->sourceModel()->data(idx, orderbook_model::CEXRatesRole).toString().toStdString());
-                if (rates > 20)
+                if (rates > 100)
                 {
                     return false;
                 }


### PR DESCRIPTION
This pull request aims to better respect the idea of the best orders widget by excluding orders that have more than 100% differences with centralized exchanges, in the idea of keeping the most interesting offers visible