### PR TITLE
feat(wallet): More explicit feedback when sending coins is not possible

### DIFF
--- a/atomic_defi_design/qml/Wallet/Main.qml
+++ b/atomic_defi_design/qml/Wallet/Main.qml
@@ -23,10 +23,6 @@ Item {
 
     readonly property var transactions_mdl: api_wallet_page.transactions_mdl
 
-    // Refreshes `Send` availability of current ticker when a new coin is added/removed
-    readonly property int portfolio_length: API.app.portfolio_pg.portfolio_mdl.length
-    onPortfolio_lengthChanged: API.app.wallet_pg.refresh_send_availability()
-
     Layout.fillHeight: true
     Layout.fillWidth: true
 
@@ -257,7 +253,6 @@ Item {
                                 text: qsTr("Yes")
                                 onClicked: {
                                     API.app.enable_coin(root.coin_to_enable_ticker)
-                                    API.app.wallet_pg.refresh_send_availability()
                                     close()
                                 }
                             }

--- a/atomic_defi_design/qml/Wallet/Main.qml
+++ b/atomic_defi_design/qml/Wallet/Main.qml
@@ -23,6 +23,10 @@ Item {
 
     readonly property var transactions_mdl: api_wallet_page.transactions_mdl
 
+    // Refreshes `Send` availability of current ticker when a new coin is added/removed
+    readonly property int portfolio_length: API.app.portfolio_pg.portfolio_mdl.length
+    onPortfolio_lengthChanged: API.app.wallet_pg.refresh_send_availability()
+
     Layout.fillHeight: true
     Layout.fillWidth: true
 
@@ -193,7 +197,10 @@ Item {
                     id: send_button
                     enabled: API.app.wallet_pg.send_available
                     text: qsTr("Send")
-                    onClicked: if (API.app.wallet_pg.send_available) send_modal.open()
+                    onClicked: {
+                        if (API.app.wallet_pg.current_ticker_fees_coin_enabled) send_modal.open()
+                        else enable_fees_coin_modal.open()
+                    }
                     width: parent.width
                     anchors.top: parent.top
                     font.pixelSize: Style.textSize
@@ -231,6 +238,37 @@ Item {
             ModalLoader {
                 id: send_modal
                 sourceComponent: SendModal {}
+            }
+
+            ModalLoader {
+                id: enable_fees_coin_modal
+                sourceComponent: BasicModal {
+                    width: 300
+                    id: root
+                    property string coin_to_enable_ticker: API.app.wallet_pg.ticker_infos.fee_ticker
+                    ModalContent {
+                        Layout.fillWidth: true
+                        title: qsTr("Enable %1 ?").arg(root.coin_to_enable_ticker)
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            DefaultButton {
+                                Layout.fillWidth: true
+                                text: qsTr("Yes")
+                                onClicked: {
+                                    API.app.enable_coin(root.coin_to_enable_ticker)
+                                    API.app.wallet_pg.refresh_send_availability()
+                                    close()
+                                }
+                            }
+                            DefaultButton {
+                                Layout.fillWidth: true
+                                text: qsTr("No")
+                                onClicked: close()
+                            }
+                        }
+                    }
+                }
             }
 
             DefaultButton {

--- a/atomic_defi_design/qml/Wallet/Main.qml
+++ b/atomic_defi_design/qml/Wallet/Main.qml
@@ -6,6 +6,8 @@ import QtCharts 2.3
 import QtWebEngine 1.8
 import QtGraphicalEffects 1.0
 
+import Qaterial 1.0 as Qaterial
+
 // Project Imports
 import "../Components"
 import "../Constants"
@@ -183,21 +185,46 @@ Item {
             Layout.alignment: Qt.AlignHCenter
             spacing: 25
 
-            DefaultButton {
-                id: send_button
-                enabled: parseFloat(current_ticker_infos.balance) > 0
-                text: qsTr("Send")
-                onClicked: send_modal.open()
+            Item {
                 Layout.fillWidth: true
-                font.pixelSize: Style.textSize
+                Layout.preferredWidth: 100
+                Layout.preferredHeight: send_button.height
+                DefaultButton {
+                    id: send_button
+                    enabled: API.app.wallet_pg.send_available
+                    text: qsTr("Send")
+                    onClicked: if (API.app.wallet_pg.send_available) send_modal.open()
+                    width: parent.width
+                    anchors.top: parent.top
+                    font.pixelSize: Style.textSize
+                    Arrow {
+                        id: arrow_send
+                        up: true
+                        color: Style.colorRed
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.right: parent.right
+                        anchors.rightMargin: 12
+                    }
+                }
 
-                Arrow {
-                    id: arrow_send
-                    up: true
-                    color: Style.colorRed
+                Image {
+                    anchors.horizontalCenter: parent.horizontalCenter
                     anchors.verticalCenter: parent.verticalCenter
-                    anchors.right: parent.right
-                    anchors.rightMargin: 12
+                    anchors.horizontalCenterOffset: -36
+                    visible: API.app.wallet_pg.send_availability_state !== ""
+                    source: Qaterial.Icons.alert
+                    ToolTip.visible: send_alert_mouse_area.containsMouse
+                    ToolTip.text: API.app.wallet_pg.send_availability_state
+                    DefaultColorOverlay {
+                        anchors.fill: parent
+                        source: parent
+                        color: "yellow"
+                    }
+                    MouseArea {
+                        id: send_alert_mouse_area
+                        anchors.fill: parent
+                        hoverEnabled: true
+                    }
                 }
             }
 

--- a/atomic_defi_design/qml/Wallet/Wallet.qml
+++ b/atomic_defi_design/qml/Wallet/Wallet.qml
@@ -1,48 +1,56 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-
 import QtGraphicalEffects 1.0
+
 import "../Components"
 import "../Constants"
 
-RowLayout {
+RowLayout
+{
     id: wallet
 
     property alias send_modal: main.send_modal
 
-    function inCurrentPage() {
+    function inCurrentPage()
+    {
         return  dashboard.inCurrentPage() &&
                 dashboard.current_page === idx_dashboard_wallet
     }
 
     // Local
-    function onClickedSwap() {
+    function onClickedSwap()
+    {
         dashboard.current_page = idx_dashboard_exchange
         dashboard.current_ticker = api_wallet_page.ticker
         API.app.trading_pg.set_pair(true, api_wallet_page.ticker)
     }
 
-    function reset() {
+    function reset()
+    {
         sidebar.reset()
     }
 
-    Component.onCompleted: reset()
-
     readonly property double button_margin: 0.05
+
     spacing: 0
     Layout.fillWidth: true
+    Component.onCompleted:
+    {
+        API.app.wallet_pg.page_open = true
+        reset()
+    }
+    Component.onDestruction: API.app.wallet_pg.page_open = false
 
     // Coins bar at left side
-    Sidebar {
+    Sidebar
+    {
         id: sidebar
-        
-
     }
 
     // Right side, main
-    Main {
+    Main
+    {
         id: main
     }
 }
-

--- a/src/core/atomicdex/pages/qt.portfolio.page.cpp
+++ b/src/core/atomicdex/pages/qt.portfolio.page.cpp
@@ -168,6 +168,7 @@ namespace atomic_dex
     {
         m_portfolio_mdl->initialize_portfolio(tickers);
         m_global_cfg_mdl->update_status(tickers, true);
+        m_system_manager.get_system<wallet_page>().check_send_availability();
     }
 
     void
@@ -175,6 +176,7 @@ namespace atomic_dex
     {
         m_portfolio_mdl->disable_coins(coins);
         m_global_cfg_mdl->update_status(coins, false);
+        m_system_manager.get_system<wallet_page>().check_send_availability();
     }
 
     WalletChartsCategories

--- a/src/core/atomicdex/pages/qt.portfolio.page.cpp
+++ b/src/core/atomicdex/pages/qt.portfolio.page.cpp
@@ -168,7 +168,6 @@ namespace atomic_dex
     {
         m_portfolio_mdl->initialize_portfolio(tickers);
         m_global_cfg_mdl->update_status(tickers, true);
-        m_system_manager.get_system<wallet_page>().check_send_availability();
     }
 
     void
@@ -176,7 +175,6 @@ namespace atomic_dex
     {
         m_portfolio_mdl->disable_coins(coins);
         m_global_cfg_mdl->update_status(coins, false);
-        m_system_manager.get_system<wallet_page>().check_send_availability();
     }
 
     WalletChartsCategories

--- a/src/core/atomicdex/pages/qt.wallet.page.cpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.cpp
@@ -40,6 +40,8 @@ namespace atomic_dex
         auto& mm2 = m_system_manager.get_system<mm2_service>();
         auto  ticker_info = mm2.get_coin_info(mm2.get_current_ticker());
         
+        SPDLOG_INFO("CHECK SEND ! {}<-{}", ticker_info.ticker, ticker_info.fees_ticker);
+        
         if (not mm2.get_balance(ticker_info.ticker) > 0)
         {
             m_send_available = false;
@@ -452,6 +454,7 @@ namespace atomic_dex
     
     void wallet_page::refresh_send_availability()
     {
+        SPDLOG_INFO("REFRESH SEND !");
         refresh_ticker_infos();
         check_send_availability();
     }

--- a/src/core/atomicdex/pages/qt.wallet.page.cpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.cpp
@@ -41,6 +41,8 @@ namespace atomic_dex
         auto  ticker_info = mm2.get_coin_info(mm2.get_current_ticker());
         
         SPDLOG_INFO("CHECK SEND ! {}<-{}", ticker_info.ticker, ticker_info.fees_ticker);
+        SPDLOG_INFO("Last error was: {}. SendAvailable:{}. CurrentTickerFeesCoinEnabled:{}",
+                    m_send_availability_state.toStdString(), m_send_available, m_current_ticker_fees_coin_enabled);
         
         if (not mm2.get_balance(ticker_info.ticker) > 0)
         {
@@ -76,6 +78,8 @@ namespace atomic_dex
             m_send_availability_state = "";
             m_current_ticker_fees_coin_enabled = true;
         }
+        SPDLOG_INFO("New error is: {}. SendAvailable:{}. CurrentTickerFeesCoinEnabled:{}",
+                    m_send_availability_state.toStdString(), m_send_available, m_current_ticker_fees_coin_enabled);
         emit sendAvailableChanged();
         emit sendAvailabilityStateChanged();
         emit currentTickerFeesCoinEnabledChanged();

--- a/src/core/atomicdex/pages/qt.wallet.page.cpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.cpp
@@ -61,7 +61,7 @@ namespace atomic_dex
         if (not mm2.get_balance(ticker_info.ticker) > 0)
         {
             m_send_available = false;
-            m_send_availability_state = tr("You do not have enough founds.");
+            m_send_availability_state = tr("You do not have enough funds.");
             m_current_ticker_fees_coin_enabled = true;
         }
         else if (ticker_info.has_parent_fees_ticker)

--- a/src/core/atomicdex/pages/qt.wallet.page.cpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.cpp
@@ -29,7 +29,21 @@ namespace atomic_dex
 
     void
     wallet_page::update()
-    {}
+    {
+        if (!m_page_open)
+        {
+            return;
+        }
+        using namespace std::chrono_literals;
+    
+        const auto now = std::chrono::high_resolution_clock::now();
+        const auto s   = std::chrono::duration_cast<std::chrono::seconds>(now - m_update_clock);
+        if (s >= 1s)
+        {
+            check_send_availability();
+            m_update_clock = std::chrono::high_resolution_clock::now();
+        }
+    }
 } // namespace atomic_dex
 
 //! Private API
@@ -317,6 +331,17 @@ namespace atomic_dex
     {
         return m_current_ticker_fees_coin_enabled;
     }
+    
+    bool wallet_page::is_page_open() const
+    {
+        return m_page_open;
+    }
+    
+    void wallet_page::set_page_open(bool value)
+    {
+        m_page_open = value;
+        emit isPageOpenChanged();
+    }
 } // namespace atomic_dex
 
 //! Public api
@@ -325,7 +350,6 @@ namespace atomic_dex
     void
     wallet_page::refresh_ticker_infos()
     {
-        // SPDLOG_DEBUG("refresh ticker infos");
         emit tickerInfosChanged();
     }
 

--- a/src/core/atomicdex/pages/qt.wallet.page.hpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.hpp
@@ -56,11 +56,13 @@ namespace atomic_dex
         void                   set_auth_succeeded() ;
         [[nodiscard]] bool     is_send_available();
         [[nodiscard]] QString  get_send_availability_state();
+        [[nodiscard]] bool     is_current_ticker_fees_coin_enabled();
         
         // QML API
         Q_INVOKABLE void claim_rewards();
         Q_INVOKABLE void claim_faucet();
-        Q_INVOKABLE void broadcast(const QString& tx_hex, bool is_claiming, bool is_max, const QString& amount) ;
+        Q_INVOKABLE void broadcast(const QString& tx_hex, bool is_claiming, bool is_max, const QString& amount);
+        Q_INVOKABLE void refresh_send_availability(); // Calls `wallet_page::check_send_availability()` from QML.
         void broadcast_on_auth_finished(bool is_auth, const QString& tx_hex, bool is_claiming, bool is_max, const QString& amount); // Broadcast requires OS local user credentials verification. This is called by the Q_INVOKABLE broadcast() method after entering credentials.
         Q_INVOKABLE void send(const QString& address, const QString& amount, bool max, bool with_fees, QVariantMap fees_data);
         
@@ -80,6 +82,7 @@ namespace atomic_dex
         Q_PROPERTY(bool auth_succeeded READ has_auth_succeeded NOTIFY auth_succeededChanged)
         Q_PROPERTY(bool send_available READ is_send_available NOTIFY sendAvailableChanged)
         Q_PROPERTY(QString send_availability_state READ get_send_availability_state NOTIFY sendAvailabilityStateChanged)
+        Q_PROPERTY(bool current_ticker_fees_coin_enabled READ is_current_ticker_fees_coin_enabled NOTIFY currentTickerFeesCoinEnabledChanged)
         
         // QML API Properties Signals
       signals:
@@ -98,6 +101,7 @@ namespace atomic_dex
         void auth_succeededChanged();
         void sendAvailabilityStateChanged();
         void sendAvailableChanged();
+        void currentTickerFeesCoinEnabledChanged();
 
       private:
         ag::ecs::system_manager& m_system_manager;
@@ -114,6 +118,7 @@ namespace atomic_dex
         bool                     m_auth_succeeded;
         bool                     m_send_available{true};
         QString                  m_send_availability_state;
+        bool                     m_current_ticker_fees_coin_enabled{true}; // Tells if the current ticker's fees coin is enabled.
     };
 } // namespace atomic_dex
 

--- a/src/core/atomicdex/pages/qt.wallet.page.hpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.hpp
@@ -16,9 +16,6 @@ namespace atomic_dex
         
         using t_qt_synchronized_json   = boost::synchronized_value<QJsonObject>;
         using t_qt_synchronized_string = boost::synchronized_value<QString>;
-        
-        // Private API
-        void check_send_availability(); // When called, refreshes `m_send_availability_state` and `m_send_available` respective values. `m_send_available` is equal to false when you cannot send the selected coin, thus `m_send_availability_state` will contain the reason of why it's not possible.
 
       public:
         explicit wallet_page(entt::registry& registry, ag::ecs::system_manager& system_manager, QObject* parent = nullptr);
@@ -58,11 +55,12 @@ namespace atomic_dex
         [[nodiscard]] QString  get_send_availability_state();
         [[nodiscard]] bool     is_current_ticker_fees_coin_enabled();
         
+        void check_send_availability(); // When called, refreshes `m_send_availability_state` and `m_send_available` respective values. `m_send_available` is equal to false when you cannot send the selected coin, thus `m_send_availability_state` will contain the reason of why it's not possible.
+    
         // QML API
         Q_INVOKABLE void claim_rewards();
         Q_INVOKABLE void claim_faucet();
         Q_INVOKABLE void broadcast(const QString& tx_hex, bool is_claiming, bool is_max, const QString& amount);
-        Q_INVOKABLE void refresh_send_availability(); // Calls `wallet_page::check_send_availability()` from QML.
         void broadcast_on_auth_finished(bool is_auth, const QString& tx_hex, bool is_claiming, bool is_max, const QString& amount); // Broadcast requires OS local user credentials verification. This is called by the Q_INVOKABLE broadcast() method after entering credentials.
         Q_INVOKABLE void send(const QString& address, const QString& amount, bool max, bool with_fees, QVariantMap fees_data);
         

--- a/src/core/atomicdex/pages/qt.wallet.page.hpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.hpp
@@ -16,6 +16,9 @@ namespace atomic_dex
         
         using t_qt_synchronized_json   = boost::synchronized_value<QJsonObject>;
         using t_qt_synchronized_string = boost::synchronized_value<QString>;
+        
+        // Private API
+        void check_send_availability(); // When called, refreshes `m_send_availability_state` and `m_send_available` respective values. `m_send_available` is equal to false when you cannot send the selected coin, thus `m_send_availability_state` will contain the reason of why it's not possible.
 
       public:
         explicit wallet_page(entt::registry& registry, ag::ecs::system_manager& system_manager, QObject* parent = nullptr);
@@ -51,6 +54,8 @@ namespace atomic_dex
         void                   set_tx_fetching_busy(bool status) ;
         [[nodiscard]] bool     has_auth_succeeded() const ;
         void                   set_auth_succeeded() ;
+        [[nodiscard]] bool     is_send_available();
+        [[nodiscard]] QString  get_send_availability_state();
         
         // QML API
         Q_INVOKABLE void claim_rewards();
@@ -73,6 +78,8 @@ namespace atomic_dex
         Q_PROPERTY(QVariant send_rpc_data READ get_rpc_send_data WRITE set_rpc_send_data NOTIFY sendDataChanged)
         Q_PROPERTY(bool tx_fetching_busy READ is_tx_fetching_busy WRITE set_tx_fetching_busy NOTIFY txFetchingStatusChanged)
         Q_PROPERTY(bool auth_succeeded READ has_auth_succeeded NOTIFY auth_succeededChanged)
+        Q_PROPERTY(bool send_available READ is_send_available NOTIFY sendAvailableChanged)
+        Q_PROPERTY(QString send_availability_state READ get_send_availability_state NOTIFY sendAvailabilityStateChanged)
         
         // QML API Properties Signals
       signals:
@@ -89,6 +96,8 @@ namespace atomic_dex
         void transactionsMdlChanged();
         void txFetchingStatusChanged();
         void auth_succeededChanged();
+        void sendAvailabilityStateChanged();
+        void sendAvailableChanged();
 
       private:
         ag::ecs::system_manager& m_system_manager;
@@ -103,6 +112,8 @@ namespace atomic_dex
         t_qt_synchronized_json   m_send_rpc_result;
         t_qt_synchronized_string m_broadcast_rpc_result;
         bool                     m_auth_succeeded;
+        bool                     m_send_available{true};
+        QString                  m_send_availability_state;
     };
 } // namespace atomic_dex
 

--- a/src/core/atomicdex/pages/qt.wallet.page.hpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.hpp
@@ -22,7 +22,7 @@ namespace atomic_dex
         void update()  override;
         ~wallet_page()  final = default;
 
-        void refresh_ticker_infos() ;
+        void refresh_ticker_infos();
         
         void on_tx_fetch_finished(const tx_fetch_finished&);
 
@@ -54,6 +54,8 @@ namespace atomic_dex
         [[nodiscard]] bool     is_send_available();
         [[nodiscard]] QString  get_send_availability_state();
         [[nodiscard]] bool     is_current_ticker_fees_coin_enabled();
+        [[nodiscard]] bool     is_page_open() const;
+        void                   set_page_open(bool value);
         
         void check_send_availability(); // When called, refreshes `m_send_availability_state` and `m_send_available` respective values. `m_send_available` is equal to false when you cannot send the selected coin, thus `m_send_availability_state` will contain the reason of why it's not possible.
     
@@ -81,6 +83,7 @@ namespace atomic_dex
         Q_PROPERTY(bool send_available READ is_send_available NOTIFY sendAvailableChanged)
         Q_PROPERTY(QString send_availability_state READ get_send_availability_state NOTIFY sendAvailabilityStateChanged)
         Q_PROPERTY(bool current_ticker_fees_coin_enabled READ is_current_ticker_fees_coin_enabled NOTIFY currentTickerFeesCoinEnabledChanged)
+        Q_PROPERTY(bool page_open READ is_page_open WRITE set_page_open NOTIFY isPageOpenChanged)
         
         // QML API Properties Signals
       signals:
@@ -100,6 +103,7 @@ namespace atomic_dex
         void sendAvailabilityStateChanged();
         void sendAvailableChanged();
         void currentTickerFeesCoinEnabledChanged();
+        void isPageOpenChanged();
 
       private:
         ag::ecs::system_manager& m_system_manager;
@@ -117,6 +121,8 @@ namespace atomic_dex
         bool                     m_send_available{true};
         QString                  m_send_availability_state;
         bool                     m_current_ticker_fees_coin_enabled{true}; // Tells if the current ticker's fees coin is enabled.
+        std::chrono::high_resolution_clock::time_point m_update_clock;      // Clock used to time the `update()` loop of this ecs system.
+        bool                     m_page_open{false};
     };
 } // namespace atomic_dex
 


### PR DESCRIPTION
Different feedbacks:

- Warn message when user has not enough funds, thus the `Send` button is disabled
- Warn message when user has not enabled the coin of the fees - in this case, clicking on `Send` button will prompt a modal to enable the fees coin
- User has no funds to pay the fees, thus the `Send` button is disabled

Related to https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/880