### PR TITLE
Remove Bottom TabBar item from Loaders (CexRate, Orders, History)

### DIFF
--- a/atomic_defi_design/qml/Components/Pagination.qml
+++ b/atomic_defi_design/qml/Components/Pagination.qml
@@ -39,11 +39,9 @@ RowLayout {
         Qaterial.ColorIcon {
             anchors.centerIn: parent
 
-            color: enabled? Style.colorWhite : Style.colorWhite6
+            color: theme.foregroundColor
             source: Qaterial.Icons.skipPreviousOutline
         }
-
-        //text: qsTr("Previous")
         enabled: visible_page > 1
         onClicked: --API.app.orders_mdl.current_page
     }
@@ -72,11 +70,9 @@ RowLayout {
         Qaterial.ColorIcon {
             anchors.centerIn: parent
 
-            color: enabled? Style.colorWhite : Style.colorWhite6
+            color: theme.foregroundColor
             source: Qaterial.Icons.skipNextOutline
         }
-
-        //text: qsTr("Next")
         enabled: page_count > 1 && visible_page < page_count
         onClicked:  ++API.app.orders_mdl.current_page
     }

--- a/atomic_defi_design/qml/Exchange/Trade/Orders/OrderList.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/Orders/OrderList.qml
@@ -11,9 +11,6 @@ Item {
     property var items
     property bool is_history: false
 
-    Layout.fillWidth: true
-    Layout.fillHeight: true
-
     ColumnLayout {
         width: parent.width-10
         height: parent.height
@@ -71,14 +68,12 @@ Item {
 
         // Pagination
         Pagination {
-            visible: is_history && API.app.orders_mdl.rowCount()>0
+            visible: is_history && list.count>0
             enabled: list.enabled
+            Layout.maximumHeight: 70
             Layout.alignment: Qt.AlignHCenter
             Layout.fillWidth: true
-            Layout.topMargin: 10
-            Layout.rightMargin: 10
-            Layout.leftMargin: 10
-            Layout.bottomMargin: Layout.topMargin
+            Layout.bottomMargin: 10
         }
     }
 }

--- a/atomic_defi_design/qml/Exchange/Trade/Orders/OrdersPage.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/Orders/OrdersPage.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.3
+import Qt.labs.platform 1.1
 
 import Qaterial 1.0 as Qaterial
 
@@ -33,11 +33,6 @@ Item {
         recover_funds_result = result
         recover_funds_modal.open()
     }
-
-//    function inCurrentPage() {
-//        return  exchange.inCurrentPage() &&
-//                exchange.current_page === page_index
-//    }
 
     function applyDateFilter() {
         list_model_proxy.filter_minimum_date = min_date.date
@@ -95,7 +90,7 @@ Item {
                 }
                 anchors.bottom: parent.bottom
                 anchors.bottomMargin: -15
-                visible: false//orders_settings.height>75
+                visible: false
                 color: Style.colorTheme5
             }
 
@@ -103,7 +98,6 @@ Item {
                 x: 5
                 y: 0
                 spacing: 0
-                //anchors.verticalCenter: parent.verticalCenter
                 Qaterial.OutlineButton {
                     icon.source: Qaterial.Icons.filter
                     text: "Filter"
@@ -130,7 +124,6 @@ Item {
                 anchors.right: parent.right
                 y: 0
                 rightPadding: 5
-                //anchors.verticalCenter: parent.verticalCenter
                 Qaterial.OutlineButton {
                     visible: root.is_history
                     Layout.leftMargin: 30
@@ -217,8 +210,6 @@ Item {
                     onAccepted: applyDateFilter()
                     Layout.preferredWidth: 130
                 }
-
-
             }
         }
 
@@ -237,20 +228,17 @@ Item {
             }
 
         }
-
-        ModalLoader {
-            id: order_modal
-            sourceComponent: OrderModal {}
-        }
+    }
+    ModalLoader {
+        id: order_modal
+        sourceComponent: OrderModal {}
     }
 
     FileDialog {
         id: export_csv_dialog
 
         title: qsTr("Please choose the CSV export name and location")
-        selectMultiple: false
-        selectExisting: false
-        selectFolder: false
+        fileMode: FileDialog.OpenFile
 
         defaultSuffix: "csv"
         nameFilters: [ "CSV files (*.csv)", "All files (*)" ]

--- a/atomic_defi_design/qml/Exchange/Trade/PriceLine.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/PriceLine.qml
@@ -7,6 +7,7 @@ import "../../Constants"
 
 // Price
 RowLayout {
+    
     readonly property string price: non_null_price
     readonly property string price_reversed: API.app.trading_pg.price_reversed
     readonly property string cex_price: API.app.trading_pg.cex_price
@@ -34,7 +35,6 @@ RowLayout {
         font.pixelSize: fontSizeBigger
     }
 
-
     ColumnLayout {
         visible: price_entered
         Layout.alignment: Qt.AlignHCenter
@@ -60,7 +60,6 @@ RowLayout {
             font.pixelSize: fontSize
         }
     }
-
 
     // Price Comparison
     ColumnLayout {
@@ -106,10 +105,6 @@ RowLayout {
             }
         }
     }
-
-
-
-
 
     // CEXchange
     ColumnLayout {

--- a/atomic_defi_design/qml/Exchange/Trade/ProView.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/ProView.qml
@@ -281,6 +281,13 @@ ColumnLayout {
                                 interactive: false
                                 currentIndex: tabView.currentIndex
                                 anchors.fill: parent
+                                onCurrentIndexChanged: {
+                                    if(currentIndex===2) {
+                                        history_component.list_model_proxy.is_history = true
+                                    } else {
+                                        history_component.list_model_proxy.is_history = false
+                                    }
+                                }
 
                                 PriceLine {
                                     id: price_line_obj

--- a/atomic_defi_design/qml/Exchange/Trade/ProView.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/ProView.qml
@@ -216,12 +216,12 @@ ColumnLayout {
                 }
                 ItemBox {
                     id: optionBox
-                    defaultHeight: tabView.currentIndex === 0 ? 200 : 400
+                    defaultHeight: tabView.currentIndex === 0 ? 200 : isUltraLarge? 400 : 270
                     Connections {
                         target: tabView
                         function onCurrentIndexChanged() {
                             if (tabView.currentIndex !== 0) {
-                                optionBox.setHeight(400)
+                                optionBox.setHeight(isUltraLarge? 400 : 270)
                             } else {
                                 optionBox.setHeight(200)
                             }
@@ -249,22 +249,6 @@ ColumnLayout {
                                 radius: 0
                                 color: theme.dexBoxBackgroundColor
                             }
-                            onCurrentIndexChanged: {
-                                swipeView.pop()
-                                switch (currentIndex) {
-                                case 0:
-                                    swipeView.push(priceLine)
-                                    break
-                                case 1:
-                                    swipeView.push(order_component)
-                                    break
-                                case 2:
-                                    swipeView.push(history_component)
-                                    break
-                                default:
-                                    priceLine
-                                }
-                            }
 
                             y: 5
                             leftPadding: 15
@@ -289,37 +273,27 @@ ColumnLayout {
                         }
                         Item {
                             anchors.horizontalCenter: parent.horizontalCenter
-                            //radius: 4
                             width: parent.width
-                            height: parent.height - (tabView.height + 40)
-                            //verticalShadow: false
-                            StackView {
+                            height: optionBox.height - (tabView.height + 40)
+                            SwipeView {
                                 id: swipeView
-
-                                initialItem: priceLine
+                                clip: true
+                                interactive: false
+                                currentIndex: tabView.currentIndex
                                 anchors.fill: parent
 
-                                LoaderBusyIndicator {
-                                    visible: swipeView.busy
+                                PriceLine {
+                                    id: price_line_obj
                                 }
-                                Component {
-                                    id: priceLine
-                                    PriceLine {
-                                        id: price_line_obj
-                                    }
-                                }
-                                Component {
+
+                                OrdersView.OrdersPage {
                                     id: order_component
-                                    OrdersView.OrdersPage {
-                                        clip: true
-                                    }
+                                    clip: true
                                 }
-                                Component {
+                                OrdersView.OrdersPage {
                                     id: history_component
-                                    OrdersView.OrdersPage {
-                                        is_history: true
-                                        clip: true
-                                    }
+                                    is_history: true
+                                    clip: true
                                 }
                             }
                         }
@@ -635,7 +609,7 @@ ColumnLayout {
                     visible: !isUltraLarge
                     SplitView.fillWidth: true
                     SplitView.fillHeight: true
-                    defaultHeight: 140
+                    defaultHeight: 130
                     minimumHeight: 80
                     title: "Best Orders"
                     reloadable: true


### PR DESCRIPTION

The multiple warning error was caused by FileDialog imported from QtQuick.Dialog 1.13 its little deprecated, i replace it by Qt.labs.platform 1.1 FileDialog, i think its better stable even if it is more maintained

- Remove CexRate, Orders, History from from Loaders
- Change FileDialog System.
- Fix some visual bug.