### PR TITLE
feat(best_orders): best orders need to be changed each time the volum…

### DIFF
--- a/atomic_defi_design/qml/Exchange/Trade/TradeBox/OrderForm.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/TradeBox/OrderForm.qml
@@ -166,10 +166,6 @@ FloatingBackground {
                 second.onPressedChanged: {
                     if(second.pressed) {
                         oldSecondValue = second.value
-                    }else {
-                        if(oldSecondValue!==second.value) {
-                            API.app.trading_pg.orderbook.refresh_best_orders()
-                        }
                     }
                 }
 

--- a/src/core/atomicdex/pages/qt.trading.page.cpp
+++ b/src/core/atomicdex/pages/qt.trading.page.cpp
@@ -657,6 +657,7 @@ namespace atomic_dex
             }
             emit volumeChanged();
             this->cap_volume();
+            this->get_orderbook_wrapper()->refresh_best_orders();
         }
     }
 

--- a/src/core/atomicdex/services/price/orderbook.scanner.service.cpp
+++ b/src/core/atomicdex/services/price/orderbook.scanner.service.cpp
@@ -43,7 +43,7 @@ namespace atomic_dex
             auto& mm2_system = m_system_manager.get_system<mm2_service>();
             if (mm2_system.is_mm2_running() && mm2_system.is_orderbook_thread_active())
             {
-                SPDLOG_INFO("process_best_orders");
+                //SPDLOG_INFO("process_best_orders");
                 using namespace std::string_literals;
                 const auto&           trading_pg = m_system_manager.get_system<trading_page>();
                 auto                  volume     = trading_pg.get_volume().toStdString();


### PR DESCRIPTION
…e change

to test:

- [x] Changing the volume manually trigger best orders
- [x] Try to spam volume change to be sure no crash is occuring on any platform
- [x] CPU should spike a bit during this spam but goes done once every request is finished