### PR TITLE
fix(addressbook): Hot fixes

### DIFF
--- a/atomic_defi_design/qml/Wallet/AddressBookAddContactAddressModal.qml
+++ b/atomic_defi_design/qml/Wallet/AddressBookAddContactAddressModal.qml
@@ -33,10 +33,12 @@ BasicModal {
         title: isEdition ? qsTr("Edit address entry") : qsTr("Create a new address")
 
         // Wallet Type Selector
-        DefaultButton {
-            implicitWidth: parent.width
+        DexButton
+        {
+            Layout.alignment: Qt.AlignHCenter
+            Layout.fillWidth: true
 
-            text: qsTr("Choose a wallet type, current: %1").arg(walletType === "" ? "NONE" : walletType)
+            text: qsTr("Selected wallet: %1").arg(walletType !== "" ? walletType : qsTr("NONE"))
 
             onClicked: wallet_type_list_modal.open()
         }

--- a/atomic_defi_design/qml/Wallet/AddressBookAddContactAddressModal.qml
+++ b/atomic_defi_design/qml/Wallet/AddressBookAddContactAddressModal.qml
@@ -1,6 +1,7 @@
 // Qt Imports
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
+import QtQuick.Controls 2.15 //> ToolTip
 
 // Project Imports
 import "../Constants"
@@ -38,9 +39,23 @@ BasicModal {
             Layout.alignment: Qt.AlignHCenter
             Layout.fillWidth: true
 
-            text: qsTr("Selected wallet: %1").arg(walletType !== "" ? walletType : qsTr("NONE"))
-
             onClicked: wallet_type_list_modal.open()
+
+            DexLabel
+            {
+                anchors.centerIn: parent
+
+                width: 320
+
+                elide: Text.ElideRight
+                wrapMode: Text.NoWrap
+
+                font: parent.font
+                text: qsTr("Selected wallet: %1").arg(walletType !== "" ? walletType : qsTr("NONE"))
+
+                ToolTip.text: text
+                ToolTip.visible: parent.containsMouse
+            }
         }
 
         // Address Key Field


### PR DESCRIPTION
- [ ] Use [QtQuick 2.15 TableView](https://doc.qt.io/qt-5/qml-qtquick-tableview.html) instead of QtQuick.Controls 1.4 TableView (for Qt 6 migration)
- [ ] Add support for BEP-20 addresses
- [x] No more text overflow handled
- [ ] Use validate/convert address from wallet page directly in addressbook frontend
- [ ] Add a fix button for address that need a conversion (same as wallet approach)