### PR TITLE
Trading view fix

### DIFF
--- a/atomic_defi_design/qml/Exchange/Trade/DexComboBoxLine.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/DexComboBoxLine.qml
@@ -30,6 +30,7 @@ RowLayout {
             anchors.left: parent.right
             anchors.leftMargin: 12
             anchors.verticalCenter: parent.verticalCenter
+            width: root.width-40
             DefaultText {
                 text_value: !details ? "" :
                             `<font color="${root.color}"><b>${details.ticker}</b></font>&nbsp;&nbsp;&nbsp;<font color="${theme.foregroundColor}">${details.name}</font>`
@@ -39,10 +40,15 @@ RowLayout {
 
             DexLabel {
                 id: bottom_line
-                text_value: !details ? "" :
+                property string real_value: !details ? "" :
                             details.balance + "  (" + General.formatFiat("", details.main_currency_balance, API.app.settings_pg.current_fiat_sign) + ")"
+                text: real_value
+                Layout.fillWidth: true
+                elide: Text.ElideRight
                 color: theme.foregroundColor
                 font: theme.textType.body2
+                wrapMode: Label.NoWrap
+                ToolTip.text: real_value
                 Component.onCompleted: {
                     font.pixelSize = 11.5
                 }

--- a/atomic_defi_design/qml/Exchange/Trade/SimpleView/Main.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/SimpleView/Main.qml
@@ -16,6 +16,7 @@ Item {
     readonly property var subPages: Main.getSubPages()
 
     // Variable which holds the current sub-page of the SimpleView.
+    property string recover_funds_result: '{}'
     property var currentSubPage: subPages.Trade
     onCurrentSubPageChanged: _selectedTabMarker.update()
 

--- a/atomic_defi_design/qml/Exchange/Trade/SimpleView/Main.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/SimpleView/Main.qml
@@ -15,8 +15,9 @@ import "Main.js" as Main
 Item {
     readonly property var subPages: Main.getSubPages()
 
-    // Variable which holds the current sub-page of the SimpleView.
     property string recover_funds_result: '{}'
+
+    // Variable which holds the current sub-page of the SimpleView.
     property var currentSubPage: subPages.Trade
     onCurrentSubPageChanged: _selectedTabMarker.update()
 
@@ -36,7 +37,7 @@ Item {
     }
     Column
     {
-        width: root.currentSubPage===subPages.Trade? simple_trade.best? 600 : 380 : 380
+        width: root.currentSubPage===subPages.Trade? _simpleTrade.best? 600 : 380 : 380
         y: 120
         spacing: 30
         anchors.horizontalCenter: parent.horizontalCenter
@@ -160,8 +161,8 @@ Item {
             Item {
                 DexRectangle {
                     id: subTradePage
-                    height: simple_trade.height
-                    width: simple_trade.best? 600 : simple_trade.coinSelection? 450 : 380
+                    height: _simpleTrade.height
+                    width: _simpleTrade.best? 600 : _simpleTrade.coinSelection? 450 : 380
                     anchors.horizontalCenter: parent.horizontalCenter
                     radius: 20
                     color: theme.dexBoxBackgroundColor
@@ -172,7 +173,7 @@ Item {
                         radius: 20 
                         Trade
                         {
-                            id: simple_trade
+                            id: _simpleTrade
                             width: parent.width
                         }
                     }

--- a/atomic_defi_design/qml/Exchange/Trade/SimpleView/Main.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/SimpleView/Main.qml
@@ -166,10 +166,14 @@ Item {
                     color: theme.dexBoxBackgroundColor
                     sizeAnimationDuration: 250
                     sizeAnimation: true
-                    Trade
-                    {
-                        id: simple_trade
-                        width: parent.width
+                    ClipRRect {
+                        anchors.fill: parent
+                        radius: 20 
+                        Trade
+                        {
+                            id: simple_trade
+                            width: parent.width
+                        }
                     }
                 }
             }
@@ -197,9 +201,6 @@ Item {
                     }
                 }
             }
-            
-            
-            
         }
     }
     ModalLoader {

--- a/atomic_defi_design/qml/Exchange/Trade/SimpleView/SubBestOrder.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/SimpleView/SubBestOrder.qml
@@ -33,7 +33,7 @@ DefaultListView
     Connections {
         target: _tradeCard
         function onBestChanged() {
-            currentIndex = 0
+            API.app.trading_pg.orderbook.best_orders.proxy_mdl.setFilterFixedString("")
             positionViewAtBeginning()
         }
     }

--- a/atomic_defi_design/qml/Exchange/Trade/SimpleView/SubCoinSelector.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/SimpleView/SubCoinSelector.qml
@@ -32,6 +32,12 @@ DefaultListView
     headerPositioning: ListView.OverlayHeader
     reuseItems: true
     cacheBuffer: 40
+    Connections {
+        target: _tradeCard
+        function onCoinSelectionChanged() {
+            API.app.trading_pg.market_pairs_mdl.left_selection_box.setFilterFixedString("")
+        }
+    }
     onVisibleChanged: {
         currentLeftToken = _tradeCard.selectedTicker
     }

--- a/atomic_defi_design/qml/Exchange/Trade/SimpleView/Trade.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/SimpleView/Trade.qml
@@ -811,7 +811,7 @@ ClipRRect // Trade Card
             height: 60
 
             enabled: !_swapAlert.visible
-            visible: _feesList.count!==0 & _tradeCard.selectedOrder!==undefined &  parseFloat(_fromValue.field.text) > 0 & !bestOrderSimplified.visible & !coinSelectorSimplified.visible
+            visible: _feesList.count !== 0 & _tradeCard.selectedOrder !== undefined &  parseFloat(_fromValue.field.text) > 0 & !bestOrderSimplified.visible & !coinSelectorSimplified.visible
 
             DexRectangle {
                 radius: 25 

--- a/atomic_defi_design/qml/Exchange/Trade/SimpleView/Trade.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/SimpleView/Trade.qml
@@ -703,6 +703,12 @@ ClipRRect // Trade Card
                     }
                 }
             }
+            Connections {
+                target: _tradeCard
+                function onCoinSelectionChanged() {
+                    _coinSearchField.text = ""
+                }
+            }
             SubCoinSelector 
             {
                 id: _coinList
@@ -754,6 +760,12 @@ ClipRRect // Trade Card
                     {
                       API.app.trading_pg.orderbook.best_orders.proxy_mdl.setFilterFixedString(text)
                     }
+                }
+            }
+            Connections {
+                target: _tradeCard
+                function onBestChanged() {
+                    _bestOrderSearchField.text = ""
                 }
             }
             SubBestOrder 

--- a/atomic_defi_design/qml/Exchange/Trade/SimpleView/Trade.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/SimpleView/Trade.qml
@@ -799,7 +799,7 @@ ClipRRect // Trade Card
             height: 60
 
             enabled: !_swapAlert.visible
-            visible: enabled & !bestOrderSimplified.visible & !coinSelectorSimplified.visible
+            visible: _feesList.count!==0 & _tradeCard.selectedOrder!==undefined &  parseFloat(_fromValue.field.text) > 0 //enabled & !bestOrderSimplified.visible & !coinSelectorSimplified.visible
 
             DexRectangle {
                 radius: 25 

--- a/atomic_defi_design/qml/Exchange/Trade/SimpleView/Trade.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/SimpleView/Trade.qml
@@ -791,7 +791,7 @@ ClipRRect // Trade Card
         }
 
 
-        DefaultRectangle // Swap Info - Details
+        Item // Swap Info - Details
         {
             id: _feesCard
             anchors.horizontalCenter: parent.horizontalCenter
@@ -801,7 +801,10 @@ ClipRRect // Trade Card
             enabled: !_swapAlert.visible
             visible: enabled & !bestOrderSimplified.visible & !coinSelectorSimplified.visible
 
-            radius: 25
+            DexRectangle {
+                radius: 25 
+                anchors.fill: parent
+            }
 
             DefaultBusyIndicator
             {

--- a/atomic_defi_design/qml/Exchange/Trade/SimpleView/Trade.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/SimpleView/Trade.qml
@@ -454,7 +454,7 @@ ClipRRect // Trade Card
                     anchors.bottomMargin: 19
                     anchors.right: parent.right
                     anchors.rightMargin: 20
-                    width: _feesCard.visible ? _bestOrderIcon.width + _bestOrderTickerText.implicitWidth + _bestOrderArrow.width + 29.5 : _piclOrderLabel.implicitWidth+20
+                    width: _tradeCard.selectedOrder!==undefined ? _bestOrderIcon.width + _bestOrderTickerText.implicitWidth + _bestOrderArrow.width + 29.5 : _piclOrderLabel.implicitWidth+20
                     height: 30
                     radius: 10
                     border.width: 0
@@ -799,7 +799,7 @@ ClipRRect // Trade Card
             height: 60
 
             enabled: !_swapAlert.visible
-            visible: _feesList.count!==0 & _tradeCard.selectedOrder!==undefined &  parseFloat(_fromValue.field.text) > 0 //enabled & !bestOrderSimplified.visible & !coinSelectorSimplified.visible
+            visible: _feesList.count!==0 & _tradeCard.selectedOrder!==undefined &  parseFloat(_fromValue.field.text) > 0 & !bestOrderSimplified.visible & !coinSelectorSimplified.visible
 
             DexRectangle {
                 radius: 25 

--- a/atomic_defi_design/qml/Exchange/Trade/Trading/TradeViewHeader.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/Trading/TradeViewHeader.qml
@@ -33,6 +33,7 @@ Item {
             width: _learnRow.implicitWidth+15
             height: 25
             radius: height/2
+            visible: false
             Behavior on color {
                 ColorAnimation {
                     duration: 150
@@ -66,6 +67,7 @@ Item {
             width: _faqRow.implicitWidth+15
             height: 25
             radius: height/2
+            visible: false
             Behavior on color {
                 ColorAnimation {
                     duration: 150

--- a/atomic_defi_design/qml/Exchange/Trade/Trading/TradeViewHeader.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/Trading/TradeViewHeader.qml
@@ -92,6 +92,7 @@ Item {
         Rectangle {
             width: 40
             height: 25
+            visible: API.app.trading_pg.current_trading_mode == TradingMode.Pro
             radius: height/2
             Behavior on color {
                 ColorAnimation {


### PR DESCRIPTION
# Various fix for trading view.
 
 ### need to check : Wrong order of animation steps on widget enlargement [1021](https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1021)
- [x]  Work
- [ ]  Not Work (Re-Check)

 ### need to check : Settings icon don't do anything on simple view [1020](https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1020)
- [ ] Work
- [ ] Not Work (Re-Check)

 ### need to check : Simple trading view widget flickering on view opening from another tab [1019](https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1019)
- [x] Work
- [ ] Not Work - (Re-Check)

 ### need to check : Search input clearing on tab switch but base/rel ticker tables still filtering until you search again [1018](https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1018)
- [x] Work
- [ ] Not Work (Re-Check)

 ### need to check : Recover funds button do not produce output on simple trading view [1016](https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1016)

- [x] Work
- [ ] Not Work (Re-Check)

 ### need to check : Amounts doesn't fit selectors in pro view in some cases [1004](https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1004)

- [x] Work
- [ ] Not Work (Re-Check)
