### PR TITLE
feat(buy_logic): fix buy logic

### DIFF
--- a/src/core/atomicdex/pages/qt.trading.page.cpp
+++ b/src/core/atomicdex/pages/qt.trading.page.cpp
@@ -145,7 +145,12 @@ namespace atomic_dex
         t_float_50 rel_min_volume_f = safe_float(get_min_trade_vol().toStdString());
         if (is_selected_order)
         {
-            SPDLOG_INFO("max_volume: {} volume: {} order_volume: {}", m_max_volume.toStdString(), m_volume.toStdString(), m_preffered_order->at("base_max_volume").get<std::string>());
+            SPDLOG_INFO("max_volume: {} volume: {} order_volume: {}, order_volume_8_digit: {}, order_volume_8_digit_extracted: {}",
+                        m_max_volume.toStdString(),
+                        m_volume.toStdString(),
+                        m_preffered_order->at("base_max_volume").get<std::string>(),
+                        utils::adjust_precision(m_preffered_order->at("base_max_volume").get<std::string>()),
+                        utils::extract_large_float(m_preffered_order->at("base_max_volume").get<std::string>()));
         }
         // SPDLOG_INFO("base_min_trade: {}", rel_min_trade.str(50, std::ios::fixed));
         // SPDLOG_INFO("rel_min_volume: {} (will be use for mm2)", rel_min_volume_f.str(50, std::ios::fixed));

--- a/src/core/atomicdex/pages/qt.trading.page.cpp
+++ b/src/core/atomicdex/pages/qt.trading.page.cpp
@@ -143,6 +143,10 @@ namespace atomic_dex
         const bool is_selected_max  = is_selected_order && is_max;
         t_float_50 rel_min_trade    = safe_float(get_orderbook_wrapper()->get_rel_min_taker_vol().toStdString());
         t_float_50 rel_min_volume_f = safe_float(get_min_trade_vol().toStdString());
+        if (is_selected_order)
+        {
+            SPDLOG_INFO("max_volume: {} volume: {} order_volume: {}", m_max_volume.toStdString(), m_volume.toStdString(), m_preffered_order->at("base_max_volume").get<std::string>());
+        }
         // SPDLOG_INFO("base_min_trade: {}", rel_min_trade.str(50, std::ios::fixed));
         // SPDLOG_INFO("rel_min_volume: {} (will be use for mm2)", rel_min_volume_f.str(50, std::ios::fixed));
 
@@ -156,7 +160,7 @@ namespace atomic_dex
             .price_numer                    = is_selected_order ? m_preffered_order->at("price_numer").get<std::string>() : "",
             .volume_denom                   = is_selected_order ? m_preffered_order->at("base_max_volume_denom").get<std::string>() : "",
             .volume_numer                   = is_selected_order ? m_preffered_order->at("base_max_volume_numer").get<std::string>() : "",
-            .is_exact_selected_order_volume = is_selected_max,
+            .is_exact_selected_order_volume = is_selected_max && m_max_volume.toStdString() == m_preffered_order->at("base_max_volume").get<std::string>(),
             .base_nota                      = base_nota.isEmpty() ? std::optional<bool>{std::nullopt} : boost::lexical_cast<bool>(base_nota.toStdString()),
             .base_confs                     = base_confs.isEmpty() ? std::optional<std::size_t>{std::nullopt} : base_confs.toUInt(),
             .min_volume = (rel_min_volume_f <= rel_min_trade) ? std::optional<std::string>{std::nullopt} : get_min_trade_vol().toStdString()};


### PR DESCRIPTION
A bug was introduced in  https://github.com/KomodoPlatform/atomicDEX-Desktop/pull/1000

thanks @cipig for the detection

please try the following use case:

- [ ] You try to swallow an order but you do not have enough balance
- [ ] You try to swallow exact selected volume and log `volume` should be equal to `base_max_volume`

(Expected behaviour is to respect your initial input)
(Please also try with order that have base_max_volume > 8 digits)
(in this particular case you have a new logs and volume should be equal 