### PR TITLE
feat(wallet_delete): Remove existing wallet

### DIFF
--- a/atomic_defi_design/qml/App.qml
+++ b/atomic_defi_design/qml/App.qml
@@ -179,6 +179,14 @@ DexRectangle {
 
         Dashboard {}
     }
+    Component {
+        id: dialogManager
+        DexDialogManager {
+
+        }  
+    }
+    
+
 
     Loader {
         id: loader
@@ -351,6 +359,25 @@ DexRectangle {
         load_theme(current.replace(".json", ""))
     }
 
+    function showDialog(data) {
+        let dialog = dialogManager.createObject(window, data)
+        for(var i in data) {
+            if(i.startsWith('on')) {
+                eval('dialog.%1.connect(data[i])'.arg(i))
+            }
+        }
+        dialog.open()
+        return dialog
+    }
+
+    function showText(data) {
+        return showDialog(data)
+    }
+    function getText(data) {
+        data['getText'] = true
+        return showText(data)
+    }
+
     Component.onCompleted: {
         selected_wallet_name !== ""
         openFirstLaunch()
@@ -405,7 +432,6 @@ DexRectangle {
         Qaterial.Style.accentColor = theme.accentColor
         console.log("END APPLY ".arg(name))
     }
-
 
     color: theme.surfaceColor
     radius: 0
@@ -515,11 +541,6 @@ DexRectangle {
             Qaterial.Style.accentColorLight = Style.colorTheme4
             Qaterial.Style.accentColorDark = Style.colorTheme4
         }
-
-        Component.onCompleted: {
-            //setQaterialStyle()
-        }
-
         onDark_themeChanged: setQaterialStyle()
 
 

--- a/atomic_defi_design/qml/Components/DexAppTextField.qml
+++ b/atomic_defi_design/qml/Components/DexAppTextField.qml
@@ -100,7 +100,7 @@ Item {
 				        }
 				        control.error = false
 			        }
-					horizontalAlignment: Qt.AlignRight
+					horizontalAlignment: Qt.AlignLeft
 			        echoMode: TextInput.Normal
 			        background: Item{}
 			        font.weight: Font.Medium

--- a/atomic_defi_design/qml/Components/DexDialogManager.qml
+++ b/atomic_defi_design/qml/Components/DexDialogManager.qml
@@ -1,0 +1,213 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import Qaterial 1.0 as Qaterial
+import QtQuick.Layouts 1.12
+
+Popup {
+    id: dialog
+    width: 350
+    dim: true
+    modal: true
+    anchors.centerIn: Overlay.overlay
+    topPadding: 0
+    bottomPadding: 0
+    leftPadding: 0
+    rightPadding: 0
+
+    Overlay.modal: Item {
+        DexRectangle {
+            anchors.fill: parent
+            color: Qt.darker(theme.dexBoxBackgroundColor)
+            opacity: .6
+        }
+    }
+
+    property bool warning: false
+
+    signal accepted(string text)
+    signal applied()
+    signal clicked(AbstractButton button)
+    signal discarded()
+    signal helpRequested()
+    signal rejected()
+    signal reset()
+
+    property string title: ""
+    property string text: ""
+    property string placeholderText: ""
+    property alias iconSource: _insideLabel.icon.source
+    property alias iconColor: _insideLabel.icon.color
+    property alias item: _col.contentItem
+    property alias itemSpacing: _insideLabel.spacing
+    property int standardButtons: Dialog.NoButton
+    property string yesButtonText: ""
+    property string cancelButtonText: ""
+    property bool getText: false
+    property bool isPassword: false
+
+    background: Qaterial.ClipRRect {
+        radius: 4
+        Rectangle {
+            anchors.fill: parent
+            radius: 4
+            color: theme.surfaceColor
+        }
+    }
+
+    focus: true
+
+    contentItem: Qaterial.ClipRRect {
+        height: _insideColumn.height
+        radius: 4
+        focus: true
+        Column {
+            id: _insideColumn
+            width: parent.width
+            padding: 0
+            topPadding: 10
+            spacing: 0
+            Item {
+                id: _header
+                height: _label.height + 10
+                width: parent.width - 20
+                anchors.horizontalCenter: parent.horizontalCenter
+
+                DexLabel {
+                    id: _label
+                    width: parent.width
+                    wrapMode: Label.Wrap
+                    leftPadding: 5
+                    font: theme.textType.body1
+                    color: theme.foregroundColor
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: dialog.title
+                }
+            }
+            Container {
+                id: _col
+                width: parent.width - 20
+                anchors.horizontalCenter: parent.horizontalCenter
+                bottomPadding: 10
+                topPadding: 10
+                leftPadding: 5
+                contentItem: Column {
+                    Qaterial.IconLabel {
+                        id: _insideLabel
+                        icon.source: dialog.iconSource
+                        icon.width: dialog.iconSource === "" ? 0 : 48
+                        icon.height: dialog.iconSource === "" ? 0 : 48
+                        icon.color: dialog.iconColor
+                        width: parent.width
+
+                        text: dialog.text
+                        wrapMode: Text.WordWrap
+                        horizontalAlignment: Label.AlignLeft
+
+                        display: dialog.iconSource === "" ? AbstractButton.TextOnly : AbstractButton.TextBesideIcon
+                    }
+
+                    Item {
+                        height: 10
+                        width: 10
+                        visible: _insideField.visible
+                    }
+
+                    DexDialogTextField {
+                        id: _insideField
+                        width: parent.width
+                        height: 45
+                        error: false
+                        visible: dialog.getText
+                        defaultBorderColor: theme.dexBoxBackgroundColor
+                        background.border.width: 2
+                        field.font: theme.textType.head6
+                        field.placeholderText: dialog.placeholderText
+                        field.rightPadding: dialog.isPassword ? 55 : 20
+                        field.echoMode: dialog.isPassword ? TextField.Password : TextField.Normal
+                        field.onAccepted: {
+                            dialog.accepted(field.text)
+                        }
+                        Qaterial.AppBarButton {
+                            visible: dialog.isPassword
+                            opacity: .8
+                            icon {
+                                source: _insideField.field.echoMode === TextField.Password ? Qaterial.Icons.eyeOffOutline : Qaterial.Icons.eyeOutline
+                                color: _insideField.field.focus ? _insideField.background.border.color : theme.accentColor
+                            }
+                            anchors {
+                                verticalCenter: parent.verticalCenter
+                                right: parent.right
+                                rightMargin: 10
+                            }
+                            onClicked: {
+                                if (_insideField.field.echoMode === TextField.Password) {
+                                    _insideField.field.echoMode = TextField.Normal
+                                } else {
+                                    _insideField.field.echoMode = TextField.Password
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            DialogButtonBox {
+                id: _dialogButtonBox
+                visible: standardButtons !== Dialog.NoButton
+                standardButtons: dialog.standardButtons
+                width: parent.width
+                height: 60
+                alignment: Qt.AlignRight
+                buttonLayout: DialogButtonBox.AndroidLayout
+                onAccepted: {
+                    if (dialog.getText) {
+                        dialog.accepted(_insideField.field.text)
+                    } else {
+                        dialog.accepted(undefined)
+                    }
+                    dialog.close()
+                }
+                onApplied: {
+                    dialog.applied()
+                    dialog.close()
+                }
+                onDiscarded: {
+                    dialog.discarded()
+                    dialog.close()
+                }
+                onHelpRequested: dialog.helpRequested()
+                onRejected: {
+                    dialog.rejected()
+                    dialog.close()
+                }
+                onReset: dialog.reset()
+                topPadding: 25
+                background: Rectangle {
+                    color: theme.dexBoxBackgroundColor
+                }
+                delegate: Qaterial.Button {
+                    id: _deleteButton
+                    flat: DialogButtonBox.buttonRole === DialogButtonBox.RejectRole
+                    bottomInset: 0
+                    topInset: 0
+                    backgroundColor: DialogButtonBox.buttonRole === DialogButtonBox.RejectRole ? 'transparent' : dialog.warning ? theme.redColor : theme.accentColor
+                    property alias cursorShape: mouseArea.cursorShape
+
+                    Component.onCompleted: {
+                        if (text === "Yes" && dialog.yesButtonText !== "") {
+                            text = dialog.yesButtonText
+                        } else if (text === "Cancel" && dialog.cancelButtonText !== "") {
+                            text = dialog.cancelButtonText
+                        }
+                    }
+
+                    MouseArea {
+                        id: mouseArea
+                        anchors.fill: parent
+                        cursorShape: "PointingHandCursor"
+                        onPressed: mouse.accepted = false
+                    }
+                }
+            }
+        }
+    }
+}

--- a/atomic_defi_design/qml/Components/DexDialogManager.qml
+++ b/atomic_defi_design/qml/Components/DexDialogManager.qml
@@ -119,13 +119,30 @@ Popup {
                         error: false
                         visible: dialog.getText
                         defaultBorderColor: theme.dexBoxBackgroundColor
-                        background.border.width: 2
-                        field.font: theme.textType.head6
+                        background.border.width: 1
+                        field.font: theme.textType.body2
                         field.placeholderText: dialog.placeholderText
                         field.rightPadding: dialog.isPassword ? 55 : 20
+                        field.leftPadding: 70
                         field.echoMode: dialog.isPassword ? TextField.Password : TextField.Normal
                         field.onAccepted: {
                             dialog.accepted(field.text)
+                        }
+                        DexRectangle {
+                            x: 3
+                            visible: dialog.isPassword
+                            height: 40
+                            width: 60
+                            radius: 20
+                            color: theme.accentColor
+                            anchors.verticalCenter: parent.verticalCenter
+                            Qaterial.ColorIcon {
+                                anchors.centerIn: parent
+                                iconSize: 19
+                                source: Qaterial.Icons.keyVariant
+                                color: theme.surfaceColor
+                            }
+
                         }
                         Qaterial.AppBarButton {
                             visible: dialog.isPassword

--- a/atomic_defi_design/qml/Components/DexDialogTextField.qml
+++ b/atomic_defi_design/qml/Components/DexDialogTextField.qml
@@ -1,0 +1,131 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import Qaterial 1.0 as Qaterial
+import QtQuick.Layouts 1.5
+
+import App 1.0
+
+Item {
+    id: control
+    width: 200
+    height: 35
+    property alias value: input_field.text
+    property alias field: input_field
+    property alias background: _background
+    property string defaultBorderColor: theme.rectangleBorderColor
+    property string leftText: ""
+    property string rightText: ""
+    property int leftWidth: -1
+    readonly property int max_length: 40
+    property bool error: false
+    onErrorChanged: {
+        if (error) {
+            _animationTimer.start()
+            _animate.start()
+        }
+    }
+    Timer {
+        id: _animationTimer
+        interval: 350
+        onTriggered: {
+            _animate.stop()
+            _background.x = 0
+        }
+    }
+    Timer {
+        id: _animate
+        interval: 30
+        repeat: true
+        onTriggered: {
+            if (_background.x == -3) {
+                _background.x = 3
+            } else {
+                _background.x = -3
+            }
+        }
+    }
+
+    function reset() {
+        input_field.text = ""
+    }
+    
+    Rectangle {
+        id: _background
+        width: parent.width
+        height: parent.height
+        radius: 6
+        color: border.color
+        border.color: theme.accentColor
+        border.width: input_field.focus ? 1 : 0
+        Behavior on x {
+            NumberAnimation {
+                duration: 40
+            }
+        }
+    }
+
+    RowLayout {
+        anchors.fill: parent
+        anchors.leftMargin: 5
+        anchors.rightMargin: 5
+        spacing: 2
+        Item {
+            visible: leftText !== ""
+            Layout.preferredWidth: leftWidth !== -1 ? leftWidth : _title_label.implicitWidth + 2
+            Layout.fillHeight: true
+            DexLabel {
+                id: _title_label
+                anchors.verticalCenter: parent.verticalCenter
+                leftPadding: 5
+                horizontalAlignment: DexLabel.AlignHCenter
+                text: leftText
+                color: theme.foregroundColor
+                opacity: .4
+                font.pixelSize: 14
+                font.weight: Font.Medium
+            }
+        }
+        Item {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Rectangle {
+                anchors.fill: parent
+                anchors.topMargin: 1
+                anchors.bottomMargin: 1
+                radius: _background.radius
+                color: theme.surfaceColor
+                DexTextField {
+                    id: input_field
+                    onTextChanged: {
+                        if (text.length > control.max_length) {
+                            text = text.substring(0, control.max_length)
+                        }
+                        control.error = false
+                    }
+                    horizontalAlignment: Qt.AlignLeft
+                    echoMode: TextInput.Normal
+                    background: Item {}
+                    font.weight: Font.Medium
+                    font.family: 'Lato'
+                    font.pixelSize: 13
+                    anchors.fill: parent
+                }
+            }
+        }
+        Item {
+            visible: rightText !== ""
+            Layout.preferredWidth: _suffix_label.implicitWidth + 2
+            Layout.fillHeight: true
+            DexLabel {
+                id: _suffix_label
+                anchors.centerIn: parent
+                horizontalAlignment: DexLabel.AlignHCenter
+                text: rightText
+                color: theme.foregroundColor
+                opacity: .4
+                font.pixelSize: 14
+                font.weight: Font.Medium
+            }
+        }
+    }
+}

--- a/atomic_defi_design/qml/Components/DexDialogTextField.qml
+++ b/atomic_defi_design/qml/Components/DexDialogTextField.qml
@@ -53,8 +53,8 @@ Item {
         id: _background
         width: parent.width
         height: parent.height
-        radius: 6
-        color: border.color
+        radius: 25
+        color: 'transparent'
         border.color: theme.accentColor
         border.width: input_field.focus ? 1 : 0
         Behavior on x {

--- a/atomic_defi_design/qml/Screens/FirstLaunch.qml
+++ b/atomic_defi_design/qml/Screens/FirstLaunch.qml
@@ -12,9 +12,12 @@ import "../Settings"
 SetupPage {
     // Override
     id: _setup
-    property var onClickedNewUser: () => {}
-    property var onClickedRecoverSeed: () => {}
-    property var onClickedWallet: () => {}
+    property
+    var onClickedNewUser: () => {}
+    property
+    var onClickedRecoverSeed: () => {}
+    property
+    var onClickedWallet: () => {}
 
 
     // Local
@@ -71,7 +74,7 @@ SetupPage {
                 }
                 Connections {
                     target: bottomDrawer
-                    function onVisibleChanged () {
+                    function onVisibleChanged() {
                         _inputPassword.field.text = ""
                     }
                 }
@@ -312,6 +315,62 @@ SetupPage {
                                 anchors.bottom: parent.bottom
                                 anchors.bottomMargin: -height / 2
                                 light: true
+                            }
+                        }
+                        Item {
+                            anchors.right: parent.right
+                            anchors.margins: 10
+                            height: parent.height
+                            width: 30
+                            Qaterial.ColorIcon {
+                                source: Qaterial.Icons.delete_
+                                iconSize: 18
+                                anchors.centerIn: parent
+                                opacity: .8
+                                color: _deleteArea.containsMouse ? theme.redColor : theme.foregroundColor
+                            }
+                            DexMouseArea {
+                                id: _deleteArea
+                                hoverEnabled: true
+                                anchors.fill: parent
+                                onClicked: {
+                                    let wallet_name = model.modelData
+                                    let dialog = app.getText({
+                                        "title": qsTr("Delete Wallet"),
+                                        text: qsTr("Do you want to delete this wallet"),
+                                        standardButtons: Dialog.Yes | Dialog.Cancel,
+                                        warning: true,
+                                        width: 300,
+                                        iconColor: theme.redColor,
+                                        isPassword: true,
+                                        placeholderText: qsTr("Type password"),
+                                        yesButtonText: qsTr("Delete"),
+                                        cancelButtonText: qsTr("Cancel"),
+                                        onAccepted: function(text) {
+                                            if (API.app.wallet_mgr.confirm_password(wallet_name, text)) {
+                                                API.app.wallet_mgr.delete_wallet(wallet_name);
+                                                app.showText({
+                                                    title: qsTr("Wallet status"),
+                                                    text: "%1 ".arg(wallet_name) + qsTr("Wallet deleted successfully"),
+                                                    standardButtons: Dialog.Ok
+                                                })
+                                                _setup.wallets = API.app.wallet_mgr.get_wallets()
+                                            } else {
+                                                app.showText({
+                                                    title: qsTr("Wallet status"),
+                                                    text: "%1 ".arg(wallet_name) + qsTr("Wallet password entered is incorrect"),
+                                                    iconSource: Qaterial.Icons.alert,
+                                                    iconColor: theme.redColor,
+                                                    warning: true,
+                                                    standardButtons: Dialog.Ok
+                                                })
+                                            }
+                                            dialog.close()
+                                            dialog.destroy()
+                                        }
+
+                                    })
+                                }
                             }
                         }
                     }

--- a/atomic_defi_design/qml/Screens/FirstLaunch.qml
+++ b/atomic_defi_design/qml/Screens/FirstLaunch.qml
@@ -337,7 +337,7 @@ SetupPage {
                                     let wallet_name = model.modelData
                                     let dialog = app.getText({
                                         "title": qsTr("Delete") + " %1 ".arg(wallet_name) + ("wallet?"),
-                                        text: qsTr("Enter password to confirm wallet delete"),
+                                        text: qsTr("Enter password to confirm deletion of") + " %1 ".arg(wallet_name) + qsTr("wallet") ,
                                         standardButtons: Dialog.Yes | Dialog.Cancel,
                                         warning: true,
                                         width: 300,

--- a/atomic_defi_design/qml/Screens/FirstLaunch.qml
+++ b/atomic_defi_design/qml/Screens/FirstLaunch.qml
@@ -336,8 +336,8 @@ SetupPage {
                                 onClicked: {
                                     let wallet_name = model.modelData
                                     let dialog = app.getText({
-                                        "title": qsTr("Delete Wallet"),
-                                        text: qsTr("Do you want to delete this wallet"),
+                                        "title": qsTr("Delete") + " %1 ".arg(wallet_name) + ("wallet?"),
+                                        text: qsTr("Enter password to confirm wallet delete"),
                                         standardButtons: Dialog.Yes | Dialog.Cancel,
                                         warning: true,
                                         width: 300,
@@ -351,14 +351,14 @@ SetupPage {
                                                 API.app.wallet_mgr.delete_wallet(wallet_name);
                                                 app.showText({
                                                     title: qsTr("Wallet status"),
-                                                    text: "%1 ".arg(wallet_name) + qsTr("Wallet deleted successfully"),
+                                                    text: "%1 ".arg(wallet_name) + qsTr("wallet deleted successfully"),
                                                     standardButtons: Dialog.Ok
                                                 })
                                                 _setup.wallets = API.app.wallet_mgr.get_wallets()
                                             } else {
                                                 app.showText({
                                                     title: qsTr("Wallet status"),
-                                                    text: "%1 ".arg(wallet_name) + qsTr("Wallet password entered is incorrect"),
+                                                    text: "%1 ".arg(wallet_name) + qsTr("wallet password entered is incorrect"),
                                                     iconSource: Qaterial.Icons.alert,
                                                     iconColor: theme.redColor,
                                                     warning: true,

--- a/qml.qrc
+++ b/qml.qrc
@@ -343,6 +343,8 @@
         <file>atomic_defi_design/qml/Components/DexCheckEye.qml</file>
         <file>atomic_defi_design/qml/Components/DexColorOverlay.qml</file>
         <file>atomic_defi_design/qml/Components/DexComboBox.qml</file>
+        <file>atomic_defi_design/qml/Components/DexDialogManager.qml</file>
+        <file>atomic_defi_design/qml/Components/DexDialogTextField.qml</file>
         <file>atomic_defi_design/qml/Components/DexFadebehavior.qml</file>
         <file>atomic_defi_design/qml/Components/DexVisibleBehavior.qml</file>
         <file>atomic_defi_design/qml/Components/DexFlickable.qml</file>


### PR DESCRIPTION
Remove existing wallet.

This pull request include two new feature, 
- getText : User input dialog and return value entered
- showText : Display a message dialog to screen 
These two new features can be improved as needed and can be used to replace the different confirmation dialog boxes that already exist in the application.

Need to test

- [x] input dialog display when user click on delete icon in startup
- [x] password work correctly
- [x] validate and check if its work
- [x] last message dialog display well.
- [x] No overflow. 

@smk762  maybe different text need to be changed.

![image](https://user-images.githubusercontent.com/39985611/125563219-586e5ff2-ac9c-4c89-acc1-1c17c39b9cfb.png)
![image](https://user-images.githubusercontent.com/39985611/125563257-6cea2c2c-d9a4-4f8d-845f-a0887e42819e.png)
![image](https://user-images.githubusercontent.com/39985611/125563302-4be6090b-869f-4238-a015-8c8191c3f1e8.png)
