### PR TITLE
fix(wallet): Windows 2FA when sending funds does not work

### DIFF
--- a/src/core/atomicdex/pages/qt.wallet.page.cpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.cpp
@@ -561,7 +561,7 @@ namespace atomic_dex
     void
     wallet_page::broadcast(const QString& tx_hex, bool is_claiming, bool is_max, const QString& amount)
     {
-#if defined(__APPLE__) || defined(WIN32)
+#if defined(__APPLE__) || defined(WIN32) || defined(_WIN32)
         QSettings& settings = this->entity_registry_.ctx<QSettings>();
         if (settings.value("2FA").toBool())
         {

--- a/vendor/antara-gaming_sdk/modules/core/antara/gaming/core/details/windows/security.authentification.cpp
+++ b/vendor/antara-gaming_sdk/modules/core/antara/gaming/core/details/windows/security.authentification.cpp
@@ -68,7 +68,14 @@ namespace antara::gaming::core::details
                     handler(true);
                     return;
                 }
-                std::cout << "Win32 LogonUserW error: " << GetLastError() << std::endl;
+
+                auto last_err = GetLastError(); // 1327 (ERROR_ACCOUNT_RESTRICTION) should mean that the user has no password set. https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--1300-1699-
+                std::cout << "Win32 LogonUserW error: " << last_err << std::endl;
+                if (last_err == 1327)
+                {
+                    handler(true);
+                    return;
+                }
             }
             else
             {


### PR DESCRIPTION
Partially solves #544 

Linux 2FA will still be missing.