### PR TITLE
fix(trade): Cancel order button was dancing in simple view

### DIFF
--- a/atomic_defi_design/qml/Exchange/Trade/SimpleView/List.qml
+++ b/atomic_defi_design/qml/Exchange/Trade/SimpleView/List.qml
@@ -261,7 +261,7 @@ DexListView {
                     bottomInset: 0
                     topInset: 0
                     outlinedColor: DexTheme.redColor
-                    visible: (!main_order.is_history? details.cancellable?? false : false)===true? (order_mouse_area.containsMouse || hovered)? true : false : false
+                    visible: !main_order.is_history && details.cancellable
                     onClicked: { if(details) cancelOrder(details.order_id) }
                     Row {
                         anchors.centerIn: parent


### PR DESCRIPTION
* `visible` condition was using `hovered` value, which should not be the case because this is unrelated. Indeed, in that case, cancel order button should be displayed only if the order is cancellable, not if the mouse is hovering the button.

Fixes #1220 