### PR TITLE
(ci)reduce gitlab artefacts storing time

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,7 +85,7 @@ AtomicDex-linux-zip:
     paths:
       - $CI_PROJECT_DIR/atomicdex-desktop-linux-${CI_COMMIT_SHA::9}.zip
     when: always
-    expire_in: 1 week
+    expire_in: 3 days
 
 AtomicDex-linux-AppImage:
   stage: upload_linux_appimage
@@ -97,7 +97,7 @@ AtomicDex-linux-AppImage:
     paths:
       - $CI_PROJECT_DIR/atomicdex-desktop-${CI_COMMIT_SHA::9}-x86_64.AppImage
     when: always
-    expire_in: 1 week
+    expire_in: 3 days
 
 AtomicDex-linux-tar:
   stage: upload_linux_tar
@@ -109,4 +109,4 @@ AtomicDex-linux-tar:
     paths:
       - $CI_PROJECT_DIR/atomicdex-desktop-linux-${CI_COMMIT_SHA::9}.tar.zst
     when: always
-    expire_in: 1 week
+    expire_in: 3 days


### PR DESCRIPTION
Reduce artifact storage time from 1 week to 3 days to avoid running out of disk space