### PR TITLE
fix(wallet): Show backend error when it's unknown when validating address

### DIFF
--- a/src/core/atomicdex/pages/qt.wallet.page.cpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.cpp
@@ -359,7 +359,7 @@ namespace atomic_dex
                 }
                 else
                 {
-                    reason                     = tr("Unknown error.");
+                    reason                     = tr("Backend error: %1").arg(reason);
                     json_result["convertible"] = false;
                 }
                 json_result["reason"] = reason;


### PR DESCRIPTION
Closes #1237 