### PR TITLE
Restore swap status text in swap/order details modal

### DIFF
--- a/atomic_defi_design/qml/Screens/Dashboard.qml
+++ b/atomic_defi_design/qml/Screens/Dashboard.qml
@@ -342,6 +342,25 @@ Item {
         }
     }
 
+    function getStatusText(status, short_text=false) {
+        switch(status) {
+            case "matching":
+                return short_text ? qsTr("Matching") : qsTr("Order Matching")
+            case "matched":
+                return short_text ? qsTr("Matched") : qsTr("Order Matched")
+            case "ongoing":
+                return short_text ? qsTr("Ongoing") : qsTr("Swap Ongoing")
+            case "successful":
+                return short_text ? qsTr("Successful") : qsTr("Swap Successful")
+            case "refunding":
+                return short_text ? qsTr("Refunding") : qsTr("Refunding")
+            case "failed":
+                return short_text ? qsTr("Failed") : qsTr("Swap Failed")
+            default:
+                return short_text ? qsTr("Unknown") : qsTr("Unknown State")
+        }
+    }
+
     function getStatusTextWithPrefix(status, short_text = false) {
         return getStatusStep(status) + " " + getStatusText(status, short_text)
     }


### PR DESCRIPTION
Resolves https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1258

Extra whitespace was due to missing elements (swap status and loading spinner) which failed to draw because a function was missing.

![image](https://user-images.githubusercontent.com/35845239/133444543-8227f56c-08f6-4fba-b190-1a2371ffd019.png)

