### PR TITLE
set ARRR-BEP20 to wallet-only

### DIFF
--- a/assets/config/0.5.1-coins.json
+++ b/assets/config/0.5.1-coins.json
@@ -157,7 +157,8 @@
       ],
       "type": "BEP-20",
       "active": false,
-      "currently_enabled": false
+      "currently_enabled": false,
+      "wallet_only": true
   },
   "AXS-BEP20": {
       "coin": "AXS-BEP20",


### PR DESCRIPTION
ARRR-BEP20 swaps don't work: https://github.com/KomodoPlatform/atomicDEX-API/issues/1078
so set it to wallet-only, like USDT-ERC20