### PR TITLE
fixing typo in xec fulcrum list

### DIFF
--- a/assets/config/0.5.2-coins.json
+++ b/assets/config/0.5.2-coins.json
@@ -3935,7 +3935,7 @@
         "url": "electrum.bitcoinabc.org:50002"
       },
       {
-        "url": "efulcrum.pepipierre.fr:50002"
+        "url": "fulcrum.pepipierre.fr:50002"
       }      
     ],
     "explorer_url": [


### PR DESCRIPTION
`fulcrum.pepipierre.fr:50002` not `efulcrum.pepipierre.fr:50002`