### PR TITLE
fix show seed modal

### DIFF
--- a/atomic_defi_design/Dex/Components/DefaultMouseArea.qml
+++ b/atomic_defi_design/Dex/Components/DefaultMouseArea.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.15
 
-MouseArea {
-    cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+MouseArea
+{
+    cursorShape: containsMouse ? Qt.PointingHandCursor : Qt.ArrowCursor
 }

--- a/atomic_defi_design/Dex/Components/DexAppButton.qml
+++ b/atomic_defi_design/Dex/Components/DexAppButton.qml
@@ -45,6 +45,8 @@ DexRectangle
                Dex.CurrentTheme.buttonColorHovered :
                Dex.CurrentTheme.buttonColorEnabled :
                Dex.CurrentTheme.buttonColorDisabled
+    opacity: _controlMouseArea.containsMouse ? 1 : .8
+
 
     Row
     {

--- a/atomic_defi_design/Dex/Components/DexAppPasswordField.qml
+++ b/atomic_defi_design/Dex/Components/DexAppPasswordField.qml
@@ -37,8 +37,8 @@ DexAppTextField
         height: 40
         width: 60
         radius: 20
-        color: DexTheme.accentColor
-        border.color: _inputPassword.focus ? DexTheme.accentColor : DexTheme.rectangleBorderColor
+        color: Dex.CurrentTheme.accentColor
+        border.color: _inputPassword.focus ? Dex.CurrentTheme.accentColor : Dex.CurrentTheme.rectangleBorderColor
         border.width: _inputPassword.focus ? 2 : 0
 
         anchors.verticalCenter: parent.verticalCenter

--- a/atomic_defi_design/Dex/Components/DexAppPasswordField.qml
+++ b/atomic_defi_design/Dex/Components/DexAppPasswordField.qml
@@ -17,7 +17,6 @@ DexAppTextField
 
     height: 50
     width: 300
-    background.border.width: 1
     background.radius: 25
     max_length: 1000
     field.echoMode: TextField.Password
@@ -38,7 +37,10 @@ DexAppTextField
         height: 40
         width: 60
         radius: 20
-        color: _inputPassword.field.focus ? _inputPassword.background.border.color : DexTheme.accentColor
+        color: DexTheme.accentColor
+        border.color: _inputPassword.focus ? DexTheme.accentColor : DexTheme.rectangleBorderColor
+        border.width: _inputPassword.focus ? 2 : 0
+
         anchors.verticalCenter: parent.verticalCenter
         Qaterial.ColorIcon
         {

--- a/atomic_defi_design/Dex/Components/DexAppTextField.qml
+++ b/atomic_defi_design/Dex/Components/DexAppTextField.qml
@@ -58,7 +58,7 @@ Item {
         width: parent.width
         height: parent.height
         radius: 4
-        color: DexTheme.surfaceColor
+        color: DexTheme.backgroundColor
         border.color: control.error ? DexTheme.redColor : input_field.focus ? DexTheme.accentColor : DexTheme.rectangleBorderColor
         border.width: input_field.focus ? 1 : 0
         Behavior on x {

--- a/atomic_defi_design/Dex/Components/DexAppTextField.qml
+++ b/atomic_defi_design/Dex/Components/DexAppTextField.qml
@@ -4,6 +4,7 @@ import Qaterial 1.0 as Qaterial
 import QtQuick.Layouts 1.5
 
 import App 1.0
+import Dex.Themes 1.0 as Dex
 
 Item {
     id: control
@@ -58,8 +59,8 @@ Item {
         width: parent.width
         height: parent.height
         radius: 4
-        color: DexTheme.backgroundColor
-        border.color: control.error ? DexTheme.redColor : input_field.focus ? DexTheme.accentColor : DexTheme.rectangleBorderColor
+        color: Dex.CurrentTheme.backgroundColor
+        border.color: control.error ? Dex.CurrentTheme.redColor : input_field.focus ? Dex.CurrentTheme.accentColor : Dex.CurrentTheme.rectangleBorderColor
         border.width: input_field.focus ? 2 : 0
         Behavior on x {
             NumberAnimation {
@@ -83,7 +84,7 @@ Item {
                 leftPadding: 5
                 horizontalAlignment: DexLabel.AlignHCenter
                 text: leftText
-                color: DexTheme.foregroundColor
+                color: Dex.CurrentTheme.foregroundColor
                 opacity: .4
                 font.pixelSize: 14
                 font.weight: Font.Medium
@@ -118,7 +119,7 @@ Item {
                     text: control.placeholderText
                     anchors.verticalCenter: parent.verticalCenter
                     leftPadding: input_field.leftPadding
-                    color: DexTheme.foregroundColor
+                    color: Dex.CurrentTheme.foregroundColor
                     font: DexTypo.body1
                     elide: DexLabel.ElideRight
                     width: parent.width - 10

--- a/atomic_defi_design/Dex/Components/DexAppTextField.qml
+++ b/atomic_defi_design/Dex/Components/DexAppTextField.qml
@@ -60,7 +60,7 @@ Item {
         radius: 4
         color: DexTheme.backgroundColor
         border.color: control.error ? DexTheme.redColor : input_field.focus ? DexTheme.accentColor : DexTheme.rectangleBorderColor
-        border.width: input_field.focus ? 1 : 0
+        border.width: input_field.focus ? 2 : 0
         Behavior on x {
             NumberAnimation {
                 duration: 40

--- a/atomic_defi_design/Dex/Components/DexAppTextField.qml
+++ b/atomic_defi_design/Dex/Components/DexAppTextField.qml
@@ -138,7 +138,7 @@ Item {
                 anchors.centerIn: parent
                 horizontalAlignment: DexLabel.AlignHCenter
                 text: rightText
-                color: DexTheme.foregroundColor
+                color: Dex.CurrentTheme.foregroundColor
                 opacity: .4
                 font.pixelSize: 14
                 font.weight: Font.Medium

--- a/atomic_defi_design/Dex/Components/DexCheckBox.qml
+++ b/atomic_defi_design/Dex/Components/DexCheckBox.qml
@@ -11,7 +11,7 @@ CheckBox
 {
     id: control
 
-    property color textColor
+    property color textColor: Dex.CurrentTheme.foregroundColor
 
     property alias boxWidth: _indicator.implicitWidth
     property alias boxHeight: _indicator.implicitHeight

--- a/atomic_defi_design/Dex/Components/DexGradientAppButton.qml
+++ b/atomic_defi_design/Dex/Components/DexGradientAppButton.qml
@@ -37,6 +37,7 @@ DexRectangle
 
     property string text: ""
     property string iconSource: ""
+    property string iconSourceRight: ""
 
     signal clicked()
 
@@ -99,6 +100,16 @@ DexRectangle
                     Dex.CurrentTheme.gradientButtonTextHoveredColor :
                     Dex.CurrentTheme.gradientButtonTextEnabledColor :
                     Dex.CurrentTheme.gradientButtonTextDisabledColor
+        }
+
+        Qaterial.ColorIcon
+        {
+            id: _iconRight
+            iconSize: _label.font.pixelSize + 2
+            visible: control.iconSourceRight === "" ? false : true
+            source: control.iconSourceRight
+            color: _label.color
+            anchors.verticalCenter: parent.verticalCenter
         }
     }
     DexMouseArea

--- a/atomic_defi_design/Dex/Components/PasswordForm.qml
+++ b/atomic_defi_design/Dex/Components/PasswordForm.qml
@@ -20,6 +20,7 @@ ColumnLayout {
         const valid_cpw = input_confirm_password.isValid()
         const matching = input_password.field.text === input_confirm_password.field.text
         return valid_pw && valid_cpw && matching
+
     }
 
     function reset() {

--- a/atomic_defi_design/Dex/Components/PasswordForm.qml
+++ b/atomic_defi_design/Dex/Components/PasswordForm.qml
@@ -20,7 +20,6 @@ ColumnLayout {
         const valid_cpw = input_confirm_password.isValid()
         const matching = input_password.field.text === input_confirm_password.field.text
         return valid_pw && valid_cpw && matching
-
     }
 
     function reset() {

--- a/atomic_defi_design/Dex/Components/TextAreaWithTitle.qml
+++ b/atomic_defi_design/Dex/Components/TextAreaWithTitle.qml
@@ -62,9 +62,11 @@ ColumnLayout {
             rightPadding: 10
             anchors.centerIn: parent
             background: DexRectangle {
-                color: DexTheme.dexBoxBackgroundColor
-                opacity: .4
+                color: DexTheme.accentColor
+                opacity: .7
                 radius: 8
+                border.color: input_field.focus ? DexTheme.accentColor : DexTheme.rectangleBorderColor
+                border.width: input_field.focus ? 2 : 0
             }
             HideFieldButton {
                 id: hide_button

--- a/atomic_defi_design/Dex/Components/TextAreaWithTitle.qml
+++ b/atomic_defi_design/Dex/Components/TextAreaWithTitle.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts 1.15
 import Qaterial 1.0 as Qaterial
 import "../Constants"
 import App 1.0
+import Dex.Themes 1.0 as Dex
 
 ColumnLayout {
     id: control
@@ -38,7 +39,7 @@ ColumnLayout {
                 x: title_text.implicitWidth + 10
                 size: 16
                 icon: Qaterial.Icons.contentCopy
-                color: copyArea.containsMouse ? DexTheme.accentColor : DexTheme.foregroundColor
+                color: copyArea.containsMouse ? Dex.CurrentTheme.accentColor : Dex.CurrentTheme.foregroundColor
                 DexMouseArea {
                     id: copyArea
                     anchors.fill: parent
@@ -62,10 +63,10 @@ ColumnLayout {
             rightPadding: 10
             anchors.centerIn: parent
             background: DexRectangle {
-                color: DexTheme.accentColor
+                color: Dex.CurrentTheme.accentColor
                 opacity: .7
                 radius: 8
-                border.color: input_field.focus ? DexTheme.accentColor : DexTheme.rectangleBorderColor
+                border.color: input_field.focus ? Dex.CurrentTheme.accentColor : Dex.CurrentTheme.rectangleBorderColor
                 border.width: input_field.focus ? 2 : 0
             }
             HideFieldButton {

--- a/atomic_defi_design/Dex/Constants/DexTheme.qml
+++ b/atomic_defi_design/Dex/Constants/DexTheme.qml
@@ -283,6 +283,7 @@ QtObject {
     readonly property string colorGreen2:  dark_theme ? "#14bca6" : "#14bca6"
     readonly property string colorGreen3:  dark_theme ? "#07433b" : "#74FBEE"
 
+    readonly property string colorWhite0:  dark_theme ? "#FFFFFF" : "#FFFFFF"
     readonly property string colorWhite1:  dark_theme ? "#FFFFFF" : "#000000"
     readonly property string colorWhite2:  dark_theme ? "#F9F9F9" : "#111111"
     readonly property string colorWhite3:  dark_theme ? "#F0F0F0" : "#222222"

--- a/atomic_defi_design/Dex/Constants/Style.qml
+++ b/atomic_defi_design/Dex/Constants/Style.qml
@@ -99,6 +99,7 @@ QtObject {
     readonly property string colorGreen2:  dark_theme ? "#14bca6" : "#14bca6"
     readonly property string colorGreen3:  dark_theme ? "#07433b" : "#74FBEE"
 
+    readonly property string colorWhite0:  dark_theme ? "#FFFFFF" : "#FFFFFF"
     readonly property string colorWhite1:  dark_theme ? "#FFFFFF" : "#000000"
     readonly property string colorWhite2:  dark_theme ? "#F9F9F9" : "#111111"
     readonly property string colorWhite3:  dark_theme ? "#F0F0F0" : "#222222"

--- a/atomic_defi_design/Dex/Portfolio/Portfolio.qml
+++ b/atomic_defi_design/Dex/Portfolio/Portfolio.qml
@@ -170,7 +170,7 @@ Item {
                             Layout.fillWidth: true
                         }
                         
-                        DefaultCheckBox
+                        DexCheckBox
                         {
                             Layout.alignment: Qt.AlignVCenter
                             text: qsTr("Show only coins with balance") + " <b>%1</b>".arg(qsTr("(%1/%2)").arg(coinsList.count).arg(portfolio_mdl.length))

--- a/atomic_defi_design/Dex/Screens/Startup/ImportWallet.qml
+++ b/atomic_defi_design/Dex/Screens/Startup/ImportWallet.qml
@@ -142,7 +142,6 @@ SetupPage
                 Layout.fillWidth: true
                 Layout.preferredHeight: 50
                 opacity: enabled ? 1 : .5
-                background.border.width: 1
                 background.radius: 25
                 field.font: DexTypo.body2
                 field.horizontalAlignment: Qt.AlignLeft
@@ -166,12 +165,6 @@ SetupPage
                         color: Dex.CurrentTheme.foregroundColor
                     }
                 }
-            }
-
-            DexLabel
-            {
-                text: qsTr("Enter seed")
-                font: DexTypo.body1
             }
 
             DexAppPasswordField
@@ -268,7 +261,6 @@ SetupPage
                     padding: 16
                     opacity: enabled ? 1 : .7
                     Layout.preferredHeight: 45
-                    anchors.verticalCenter: parent.verticalCenter
                     iconSourceRight: Qaterial.Icons.arrowRight
                 }
             }
@@ -339,7 +331,6 @@ SetupPage
                     padding: 16
                     opacity: enabled ? 1 : .7
                     Layout.preferredHeight: 45
-                    anchors.verticalCenter: parent.verticalCenter
                     iconSourceRight: Qaterial.Icons.arrowRight
                     onClicked: trySubmit()
                 }

--- a/atomic_defi_design/Dex/Screens/Startup/ImportWallet.qml
+++ b/atomic_defi_design/Dex/Screens/Startup/ImportWallet.qml
@@ -144,7 +144,7 @@ SetupPage
                 opacity: enabled ? 1 : .5
                 background.border.width: 1
                 background.radius: 25
-                field.font: DexTypo.head6
+                field.font: DexTypo.body2
                 field.horizontalAlignment: Qt.AlignLeft
                 field.leftPadding: 75
                 field.placeholderText: qsTr("Wallet Name")
@@ -180,6 +180,7 @@ SetupPage
                 Layout.fillWidth: true
                 Layout.preferredHeight: 50
                 leftIcon: Qaterial.Icons.fileKey
+                field.font: DexTypo.body2
                 field.placeholderText: qsTr('Enter seed')
                 field.onAccepted: tryPassLevel1()
                 field.onTextChanged:
@@ -253,35 +254,22 @@ SetupPage
                     Layout.preferredHeight: 10
                 }
 
-                DexAppButton
+
+                DexGradientAppButton
                 {
                     id: nextButton
                     enabled: input_wallet_name.field.text !== "" && _seedField.field.text !== ""
                     onClicked: tryPassLevel1()
                     radius: 20
-                    opacity: enabled ? 1 : .4
-                    Layout.preferredWidth: _nextRow.implicitWidth + 40
+
+                    text: qsTr("Next")
+                    leftPadding: 5
+                    rightPadding: 5
+                    padding: 16
+                    opacity: enabled ? 1 : .7
                     Layout.preferredHeight: 45
-                    label.color: 'transparent'
-                    Row
-                    {
-                        id: _nextRow
-                        anchors.centerIn: parent
-                        spacing: 10
-                        DexLabel
-                        {
-                            text: qsTr("Next")
-                            font: DexTypo.button
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-                        Qaterial.ColorIcon
-                        {
-                            anchors.verticalCenter: parent.verticalCenter
-                            color: Dex.CurrentTheme.foregroundColor
-                            source: Qaterial.Icons.arrowRight
-                            iconSize: 14
-                        }
-                    }
+                    anchors.verticalCenter: parent.verticalCenter
+                    iconSourceRight: Qaterial.Icons.arrowRight
                 }
             }
 
@@ -303,6 +291,7 @@ SetupPage
             DexAppPasswordField
             {
                 id: _inputPassword
+                field.font: DexTypo.body2
                 Layout.fillWidth: true
                 Layout.preferredHeight: 50
                 field.onAccepted: trySubmit()
@@ -320,6 +309,8 @@ SetupPage
             DexAppPasswordField
             {
                 id: _inputPasswordConfirm
+                field.font: DexTypo.body2
+                field.placeholderText: qsTr("Enter the same password to confirm")
                 Layout.fillWidth: true
                 Layout.preferredHeight: 50
                 field.onAccepted: trySubmit()
@@ -336,35 +327,21 @@ SetupPage
                     Layout.preferredHeight: 10
                 }
 
-                DexAppButton
+
+                DexGradientAppButton
                 {
                     id: submit_button
                     enabled: _keyChecker.isValid()
-                    opacity: enabled ? 1 : .4
-                    onClicked: trySubmit()
+                    text: qsTr("Continue")
                     radius: 20
-                    Layout.preferredWidth: _nextRow2.implicitWidth + 40
+                    leftPadding: 5
+                    rightPadding: 5
+                    padding: 16
+                    opacity: enabled ? 1 : .7
                     Layout.preferredHeight: 45
-                    label.color: 'transparent'
-                    Row
-                    {
-                        id: _nextRow2
-                        anchors.centerIn: parent
-                        spacing: 10
-                        DefaultText
-                        {
-                            text: qsTr("Continue")
-                            font: DexTypo.button
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-                        Qaterial.ColorIcon
-                        {
-                            anchors.verticalCenter: parent.verticalCenter
-                            source: Qaterial.Icons.arrowRight
-                            color: Dex.CurrentTheme.foregroundColor
-                            iconSize: 14
-                        }
-                    }
+                    anchors.verticalCenter: parent.verticalCenter
+                    iconSourceRight: Qaterial.Icons.arrowRight
+                    onClicked: trySubmit()
                 }
             }
 

--- a/atomic_defi_design/Dex/Screens/Startup/NewWallet.qml
+++ b/atomic_defi_design/Dex/Screens/Startup/NewWallet.qml
@@ -420,7 +420,7 @@ SetupPage
                     rightPadding: 5
                     padding: 16
                     enabled: input_wallet_name.field.text !== ""
-                    opacity: enabled ? 1 : .4
+                    opacity: enabled ? 1 : .7
                     Layout.preferredHeight: 45
                     anchors.verticalCenter: parent.verticalCenter
                     iconSourceRight: Qaterial.Icons.arrowRight
@@ -456,12 +456,13 @@ SetupPage
         {
             visible: currentStep === 1
 
-            FloatingBackground
+            Rectangle
             {
                 Layout.topMargin: 10
                 Layout.bottomMargin: Layout.topMargin
                 Layout.fillWidth: true
                 height: 140
+                radius: 20
 
                 Column
                 {
@@ -515,7 +516,7 @@ SetupPage
                                 width: (_insideFlow2.width - 30) / 4
                                 text: modelData ?? ""
                                 radius: 20
-                                color: Dex.CurrentTheme.colorWhite0
+                                color: Dex.CurrentTheme.accentColor
                                 font: DexTypo.body2
 
                                 onClicked:
@@ -543,7 +544,7 @@ SetupPage
                 opacity: enabled ? 1 : .5
                 background.border.width: 1
                 background.radius: 25
-                field.font: DexTypo.body1
+                field.font: DexTypo.body2
                 field.horizontalAlignment: Qt.AlignLeft
                 field.leftPadding: 75
                 field.placeholderText: qsTr("Enter the %n. word", "", current_word_idx + 1)
@@ -586,37 +587,20 @@ SetupPage
                     Layout.preferredHeight: 10
                 }
 
-                DexAppButton
+                DexGradientAppButton
                 {
                     id: checkForNext
-                    enabled: validGuessField(input_seed_word.field)
-                    opacity: enabled ? 1 : .4
-                    onClicked: tryGuess()
+                    text: qsTr("Check")
                     radius: 20
-                    Layout.preferredWidth: _nextRow3.implicitWidth + 40
+                    leftPadding: 5
+                    rightPadding: 5
+                    padding: 16
+                    opacity: enabled ? 1 : .7
                     Layout.preferredHeight: 45
-                    label.color: 'transparent'
-                    Row
-                    {
-                        id: _nextRow3
-                        anchors.centerIn: parent
-                        spacing: 10
-                        DefaultText
-                        {
-                            text: qsTr("Check")
-                            font: DexTypo.button
-                            color: Dex.CurrentTheme.foregroundColor
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-
-                        Qaterial.ColorIcon
-                        {
-                            anchors.verticalCenter: parent.verticalCenter
-                            color: Dex.CurrentTheme.foregroundColor
-                            source: Qaterial.Icons.check
-                            iconSize: 14
-                        }
-                    }
+                    anchors.verticalCenter: parent.verticalCenter
+                    iconSourceRight: Qaterial.Icons.check
+                    enabled: validGuessField(input_seed_word.field)
+                    onClicked: tryGuess()
                 }
             }
 
@@ -672,36 +656,22 @@ SetupPage
                     Layout.preferredHeight: 10
                 }
 
-                DexAppButton
+
+
+                DexGradientAppButton
                 {
                     id: finalRegisterButton
-                    enabled: _keyChecker.isValid()
-                    opacity: enabled ? 1 : .4
+                    text: qsTr("Continue")
                     radius: 20
-                    Layout.preferredWidth: _nextRow2.implicitWidth + 40
+                    leftPadding: 5
+                    rightPadding: 5
+                    padding: 16
+                    opacity: enabled ? 1 : .7
                     Layout.preferredHeight: 45
-                    label.color: 'transparent'
+                    anchors.verticalCenter: parent.verticalCenter
+                    iconSourceRight: Qaterial.Icons.arrowRight
+                    enabled: _keyChecker.isValid()
                     onClicked: eula_modal.open()
-
-                    Row
-                    {
-                        id: _nextRow2
-                        anchors.centerIn: parent
-                        spacing: 10
-                        DefaultText
-                        {
-                            text: qsTr("Continue")
-                            font: DexTypo.button
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-                        Qaterial.ColorIcon
-                        {
-                            anchors.verticalCenter: parent.verticalCenter
-                            source: Qaterial.Icons.arrowRight
-                            color: Dex.CurrentTheme.foregroundColor
-                            iconSize: 14
-                        }
-                    }
                 }
             }
 

--- a/atomic_defi_design/Dex/Screens/Startup/NewWallet.qml
+++ b/atomic_defi_design/Dex/Screens/Startup/NewWallet.qml
@@ -346,7 +346,7 @@ SetupPage
                         implicitWidth: 45
                         backgroundColor: "transparent"
                         icon.source: Qaterial.Icons.contentCopy
-                        icon.color: DexTheme.foregroundColor
+                        icon.color: Dex.CurrentTheme.foregroundColor
                         Layout.alignment: Qt.AlignVCenter
 
                         DefaultMouseArea

--- a/atomic_defi_design/Dex/Screens/Startup/NewWallet.qml
+++ b/atomic_defi_design/Dex/Screens/Startup/NewWallet.qml
@@ -256,7 +256,6 @@ SetupPage
                 Layout.fillWidth: true
                 Layout.preferredHeight: 50
                 opacity: enabled ? 1 : .5
-                background.border.width: 1
                 background.radius: 25
                 field.onAccepted: completeForm()
                 field.font: DexTypo.body1
@@ -378,7 +377,7 @@ SetupPage
                             {
                                 width: (_insideFlow.width - 30) / 4
                                 height: _insideLabel.implicitHeight + 10
-                                color: Dex.CurrentTheme.colorWhite0
+                                color: Style.colorWhite0
                                 radius: 10
                                 opacity: .8
                                 DefaultText
@@ -422,7 +421,6 @@ SetupPage
                     enabled: input_wallet_name.field.text !== ""
                     opacity: enabled ? 1 : .7
                     Layout.preferredHeight: 45
-                    anchors.verticalCenter: parent.verticalCenter
                     iconSourceRight: Qaterial.Icons.arrowRight
 
                     onClicked:
@@ -542,7 +540,6 @@ SetupPage
                 Layout.fillWidth: true
                 Layout.preferredHeight: 50
                 opacity: enabled ? 1 : .5
-                background.border.width: 1
                 background.radius: 25
                 field.font: DexTypo.body2
                 field.horizontalAlignment: Qt.AlignLeft
@@ -597,7 +594,6 @@ SetupPage
                     padding: 16
                     opacity: enabled ? 1 : .7
                     Layout.preferredHeight: 45
-                    anchors.verticalCenter: parent.verticalCenter
                     iconSourceRight: Qaterial.Icons.check
                     enabled: validGuessField(input_seed_word.field)
                     onClicked: tryGuess()
@@ -669,7 +665,6 @@ SetupPage
                     padding: 16
                     opacity: enabled ? 1 : .7
                     Layout.preferredHeight: 45
-                    anchors.verticalCenter: parent.verticalCenter
                     iconSourceRight: Qaterial.Icons.arrowRight
                     enabled: _keyChecker.isValid()
                     onClicked: eula_modal.open()

--- a/atomic_defi_design/Dex/Screens/Startup/NewWallet.qml
+++ b/atomic_defi_design/Dex/Screens/Startup/NewWallet.qml
@@ -641,6 +641,7 @@ SetupPage
                 id: _inputPasswordConfirm
                 Layout.fillWidth: true
                 Layout.preferredHeight: 50
+                field.placeholderText: qsTr("Enter the same password to confirm")
                 field.onAccepted: _keyChecker.isValid() ? eula_modal.open() : undefined
             }
 

--- a/atomic_defi_design/Dex/Screens/Startup/NewWallet.qml
+++ b/atomic_defi_design/Dex/Screens/Startup/NewWallet.qml
@@ -373,13 +373,13 @@ SetupPage
                         Repeater
                         {
                             model: current_mnemonic.split(" ")
-                            delegate: DefaultRectangle
+                            delegate: DexAppButton
                             {
                                 width: (_insideFlow.width - 30) / 4
                                 height: _insideLabel.implicitHeight + 10
-                                color: Style.colorWhite0
                                 radius: 10
                                 opacity: .8
+                                color: Dex.CurrentTheme.backgroundColor
                                 DefaultText
                                 {
                                     id: _insideLabel

--- a/atomic_defi_design/Dex/Screens/Startup/NewWallet.qml
+++ b/atomic_defi_design/Dex/Screens/Startup/NewWallet.qml
@@ -259,7 +259,7 @@ SetupPage
                 background.border.width: 1
                 background.radius: 25
                 field.onAccepted: completeForm()
-                field.font: DexTypo.head6
+                field.font: DexTypo.body1
                 field.horizontalAlignment: Qt.AlignLeft
                 field.leftPadding: 75
                 field.placeholderText: "Wallet Name"
@@ -290,6 +290,7 @@ SetupPage
                 Layout.fillWidth: true
                 color: Dex.CurrentTheme.noColor
                 height: warning_texts.height + 20
+                radius: 20
 
                 Column
                 {
@@ -303,6 +304,7 @@ SetupPage
                     DefaultText
                     {
                         width: parent.width - 40
+                        color: Style.colorWhite0
                         horizontalAlignment: Text.AlignHCenter
                         anchors.horizontalCenter: parent.horizontalCenter
                         text_value: qsTr("Important: Back up your seed phrase before proceeding!")
@@ -310,6 +312,7 @@ SetupPage
 
                     DefaultText {
                         width: parent.width - 40
+                        color: Style.colorWhite0
                         horizontalAlignment: Text.AlignHCenter
                         anchors.horizontalCenter: parent.horizontalCenter
                         text_value: qsTr("We recommend storing it offline.")
@@ -339,15 +342,24 @@ SetupPage
                         Layout.alignment: Qt.AlignVCenter
                     }
 
-                    Qaterial.AppBarButton
+                    Qaterial.RawMaterialButton
                     {
+                        implicitWidth: 45
+                        backgroundColor: "transparent"
                         icon.source: Qaterial.Icons.contentCopy
+                        icon.color: DexTheme.foregroundColor
                         Layout.alignment: Qt.AlignVCenter
-                        onClicked: {
-                            input_generated_seed.selectAll()
-                            input_generated_seed.copy()
-                            toast.show(qsTr("Copied to Clipboard"), General.time_toast_basic_info, "", false)
-                        }
+
+                        DefaultMouseArea
+                        {
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            onClicked:
+                            {
+                                API.qt_utilities.copy_text_to_clipboard(input_generated_seed.text)
+                                app.notifyCopy(qsTr("Seed phrase"), qsTr("copied to clipboard"))
+                            }
+                        }                            
                     }
                 }
                 Item
@@ -365,8 +377,9 @@ SetupPage
                             delegate: DefaultRectangle
                             {
                                 width: (_insideFlow.width - 30) / 4
-                                height: _insideLabel.implicitHeight + 15
-                                color: Dex.CurrentTheme.innerBackgroundColor
+                                height: _insideLabel.implicitHeight + 10
+                                color: Dex.CurrentTheme.colorWhite0
+                                radius: 10
                                 opacity: .8
                                 DefaultText
                                 {
@@ -398,16 +411,19 @@ SetupPage
                     Layout.preferredHeight: 10
                 }
 
-                DexAppButton
+                DexGradientAppButton
                 {
                     id: nextButton
-
-                    enabled: input_wallet_name.field.text !== ""
+                    text: qsTr("Next")
                     radius: 20
+                    leftPadding: 5
+                    rightPadding: 5
+                    padding: 16
+                    enabled: input_wallet_name.field.text !== ""
                     opacity: enabled ? 1 : .4
-                    Layout.preferredWidth: _nextRow.implicitWidth + 40
                     Layout.preferredHeight: 45
-                    label.color: 'transparent'
+                    anchors.verticalCenter: parent.verticalCenter
+                    iconSourceRight: Qaterial.Icons.arrowRight
 
                     onClicked:
                     {
@@ -422,27 +438,6 @@ SetupPage
                         input_seed_word.field.text = ""
                         guess_count = 1
                         setRandomGuessWord()
-                    }
-
-                    Row
-                    {
-                        id: _nextRow
-                        anchors.centerIn: parent
-                        spacing: 10
-                        DefaultText
-                        {
-                            text: qsTr("Next")
-                            font: DexTypo.button
-                            color: Dex.CurrentTheme.foregroundColor
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-                        Qaterial.ColorIcon
-                        {
-                            anchors.verticalCenter: parent.verticalCenter
-                            color: Dex.CurrentTheme.foregroundColor
-                            source: Qaterial.Icons.arrowRight
-                            iconSize: 14
-                        }
                     }
                 }
             }
@@ -514,10 +509,15 @@ SetupPage
                         {
                             id: mmo
                             model: getRandom4x(current_mnemonic.split(" "), getWords()[current_word_idx])
+
                             delegate: DexAppButton
                             {
                                 width: (_insideFlow2.width - 30) / 4
                                 text: modelData ?? ""
+                                radius: 20
+                                color: Dex.CurrentTheme.colorWhite0
+                                font: DexTypo.body2
+
                                 onClicked:
                                 {
                                     input_seed_word.field.text = modelData
@@ -543,7 +543,7 @@ SetupPage
                 opacity: enabled ? 1 : .5
                 background.border.width: 1
                 background.radius: 25
-                field.font: DexTypo.head6
+                field.font: DexTypo.body1
                 field.horizontalAlignment: Qt.AlignLeft
                 field.leftPadding: 75
                 field.placeholderText: qsTr("Enter the %n. word", "", current_word_idx + 1)
@@ -562,7 +562,7 @@ SetupPage
                     DefaultText
                     {
                         anchors.centerIn: parent
-                        font: DexTypo.head6
+                        font: DexTypo.body1
                         text: current_word_idx + 1
                     }
 

--- a/atomic_defi_design/Dex/Screens/Startup/WalletsView.qml
+++ b/atomic_defi_design/Dex/Screens/Startup/WalletsView.qml
@@ -51,7 +51,7 @@ SetupPage
 
         Item { Layout.fillWidth: true }
 
-        DefaultButton
+        DexAppButton
         {
             Layout.fillWidth: true
             horizontalAlignment: Qt.AlignLeft
@@ -63,7 +63,7 @@ SetupPage
             onClicked: newWalletClicked()
         }
 
-        DefaultButton
+        DexAppButton
         {
             text: qsTr("Import wallet")
             horizontalAlignment: Qt.AlignLeft

--- a/atomic_defi_design/Dex/Settings/RecoverSeedModal.qml
+++ b/atomic_defi_design/Dex/Settings/RecoverSeedModal.qml
@@ -174,7 +174,7 @@ BasicModal
                             implicitWidth: 45
                             backgroundColor: "transparent"
                             icon.source: Qaterial.Icons.qrcodeScan
-                            icon.color: DexTheme.foregroundColor
+                            icon.color: Dex.CurrentTheme.foregroundColor
 
                             DefaultMouseArea
                             {
@@ -194,7 +194,7 @@ BasicModal
                             implicitWidth: 45
                             backgroundColor: "transparent"
                             icon.source: Qaterial.Icons.contentCopy
-                            icon.color: DexTheme.foregroundColor
+                            icon.color: Dex.CurrentTheme.foregroundColor
 
                             DefaultMouseArea
                             {
@@ -215,7 +215,7 @@ BasicModal
                             implicitWidth: 45
                             backgroundColor: "transparent"
                             icon.source: Qaterial.Icons.qrcodeScan
-                            icon.color: DexTheme.foregroundColor
+                            icon.color: Dex.CurrentTheme.foregroundColor
 
                             DefaultMouseArea
                             {
@@ -235,13 +235,14 @@ BasicModal
                             implicitWidth: 45
                             backgroundColor: "transparent"
                             icon.source: Qaterial.Icons.contentCopy
-                            icon.color: DexTheme.foregroundColor
+                            icon.color: Dex.CurrentTheme.foregroundColor
 
                             DefaultMouseArea
                             {
                                 anchors.fill: parent
                                 hoverEnabled: true
-                                onClicked: {
+                                onClicked:
+                                {
                                     API.qt_utilities.copy_text_to_clipboard(rpc_pw.text)
                                     app.notifyCopy(qsTr("RPC password"), qsTr("phrase key copied to clipboard"))
                                 }
@@ -344,7 +345,7 @@ BasicModal
                                 implicitWidth: 45
                                 backgroundColor: "transparent"
                                 icon.source: Qaterial.Icons.qrcodeScan
-                                icon.color: DexTheme.foregroundColor
+                                icon.color: Dex.CurrentTheme.foregroundColor
 
                                 DefaultMouseArea
                                 {
@@ -365,7 +366,7 @@ BasicModal
                                 implicitWidth: 45
                                 backgroundColor: "transparent"
                                 icon.source: Qaterial.Icons.contentCopy
-                                icon.color: DexTheme.foregroundColor
+                                icon.color: Dex.CurrentTheme.foregroundColor
 
                                 DefaultMouseArea
                                 {
@@ -387,7 +388,7 @@ BasicModal
                                 implicitWidth: 45
                                 backgroundColor: "transparent"
                                 icon.source: Qaterial.Icons.qrcodeScan
-                                icon.color: DexTheme.foregroundColor
+                                icon.color: Dex.CurrentTheme.foregroundColor
 
                                 DefaultMouseArea
                                 {
@@ -408,13 +409,14 @@ BasicModal
                                 implicitWidth: 45
                                 backgroundColor: "transparent"
                                 icon.source: Qaterial.Icons.contentCopy
-                                icon.color: DexTheme.foregroundColor
+                                icon.color: Dex.CurrentTheme.foregroundColor
 
                                 DefaultMouseArea
                                 {
                                     anchors.fill: parent
                                     hoverEnabled: true
-                                    onClicked: {
+                                    onClicked:
+                                    {
                                         API.qt_utilities.copy_text_to_clipboard(model.priv_key)
                                         app.notifyCopy(qsTr("%1 private key").arg(model.ticker), qsTr("copied to clipboard"))
                                     }

--- a/atomic_defi_design/Dex/Settings/RecoverSeedModal.qml
+++ b/atomic_defi_design/Dex/Settings/RecoverSeedModal.qml
@@ -9,7 +9,8 @@ import "../Constants"
 import App 1.0
 import Dex.Themes 1.0 as Dex
 
-BasicModal {
+BasicModal
+{
     id: root
 
     property var portfolio_model: API.app.portfolio_pg.portfolio_mdl
@@ -17,26 +18,30 @@ BasicModal {
 
     property bool wrong_password: false
 
-    function tryViewSeed() {
+    function tryViewSeed()
+    {
         if(!submit_button.enabled) return
 
         const result = API.app.settings_pg.retrieve_seed(API.app.wallet_mgr.wallet_default_name, input_password.field.text)
 
-        if(result.length === 2) {
+        if(result.length === 2)
+        {
             seed_text.text = result[0]
             rpc_pw.text = result[1]
             wrong_password = false
             root.nextPage()
             loading.running = true
         }
-        else {
+        else
+        {
             wrong_password = true
         }
     }
 
     width: 800
 
-    onClosed: {
+    onClosed:
+    {
         wrong_password = false
         input_password.reset()
         seed_text.text = ""
@@ -44,11 +49,14 @@ BasicModal {
         currentIndex = 0
     }
 
-    ModalContent { // Password checking
+    ModalContent
+    {
         title: qsTr("View seed and private keys")
 
-        ColumnLayout {
-            DefaultText {
+        ColumnLayout
+        {
+            DefaultText
+            {
                 Layout.topMargin: 10
                 Layout.bottomMargin: 10
                 Layout.alignment: Qt.AlignHCenter
@@ -56,14 +64,19 @@ BasicModal {
                 text_value: qsTr("Please enter your password to view the seed.")
             }
 
-            PasswordForm {
+            DexAppPasswordField
+            {
                 id: input_password
                 Layout.fillWidth: true
-                confirm: false
                 field.onAccepted: tryViewSeed()
+                background.color: Dex.CurrentTheme.floatingBackgroundColor
+
+                leftIconColor: Dex.CurrentTheme.foregroundColor
+                hideFieldButton.icon.color: Dex.CurrentTheme.foregroundColor
             }
 
-            DefaultText {
+            DefaultText
+            {
                 text_value: qsTr("Wrong Password")
                 color: Style.colorRed
                 visible: wrong_password
@@ -71,14 +84,17 @@ BasicModal {
         }
 
         // Buttons
-        footer: [
-            DefaultButton {
+        footer:
+        [
+            DefaultButton
+            {
                 text: qsTr("Cancel")
                 Layout.fillWidth: true
                 onClicked: root.close()
             },
 
-            PrimaryButton {
+            PrimaryButton
+            {
                 id: submit_button
                 text: qsTr("View")
                 Layout.fillWidth: true
@@ -88,17 +104,21 @@ BasicModal {
         ]
     }
 
-    ModalContent {
+    ModalContent
+    {
         title: qsTr("View seed and private keys")
         Layout.fillWidth: true
 
-        Timer {
+        Timer
+        {
             id: loading
 
             repeat: true
             running: false
-            onTriggered: {
-                if (!settings_page.fetching_priv_keys_busy) {
+            onTriggered:
+            {
+                if (!settings_page.fetching_priv_keys_busy)
+                {
                     repeat = false
                     busy_view.visible = false
                     busy_view.enabled = false
@@ -110,102 +130,153 @@ BasicModal {
             }
         }
 
-        DefaultBusyIndicator {
+        DefaultBusyIndicator
+        {
             id: busy_view
-
             Layout.alignment: Qt.AlignHCenter
         }
 
-        DefaultRectangle {
+        DefaultRectangle
+        {
             id: seed_container
             visible: false
             enabled: false
             height: 120
             width: parent.width
 
-            RowLayout {
+            RowLayout
+            {
                 Layout.fillWidth: true
                 anchors.verticalCenter: parent.verticalCenter
 
-                DefaultImage {
+                DefaultImage
+                {
                     Layout.leftMargin: 10
                     source: Dex.CurrentTheme.bigLogoPath
                     Layout.preferredWidth: 32
                     Layout.preferredHeight: 32
                 }
 
-                DefaultText {
+                DefaultText
+                {
                     Layout.leftMargin: 5
                     Layout.preferredWidth: 100
                     text: API.app_name
                     font.pixelSize: Style.textSizeSmall5
                 }
 
-                ColumnLayout {
-                    RowLayout {
-                Qaterial.RawMaterialButton {
-                    implicitWidth: 45
-                    backgroundColor: "transparent"
-                    icon.source: Qaterial.Icons.qrcodeScan
-
-                    onClicked: {
-                        qrcode_modal.qrcode_svg = API.qt_utilities.get_qrcode_svg_from_string(seed_text.text)
-                        qrcode_modal.open()
-                    }
-                }
-
-                Qaterial.RawMaterialButton { //! Copy clipboard button
-                    implicitWidth: 45
-                    backgroundColor: "transparent"
-                    icon.source: Qaterial.Icons.contentCopy
-
-                    onClicked: API.qt_utilities.copy_text_to_clipboard(seed_text.text)
-                }
-                    }
-                    RowLayout {
-                        Qaterial.RawMaterialButton {
+                ColumnLayout
+                {
+                    RowLayout
+                    {
+                        Qaterial.RawMaterialButton
+                        {
                             implicitWidth: 45
                             backgroundColor: "transparent"
                             icon.source: Qaterial.Icons.qrcodeScan
+                            icon.color: DexTheme.foregroundColor
 
-                            onClicked: {
-                                qrcode_modal.qrcode_svg = API.qt_utilities.get_qrcode_svg_from_string(rpc_pw.text)
-                                qrcode_modal.open()
+                            DefaultMouseArea
+                            {
+                                anchors.fill: parent
+                                hoverEnabled: true
+
+                                onClicked:
+                                {
+                                    qrcode_modal.qrcode_svg = API.qt_utilities.get_qrcode_svg_from_string(seed_text.text)
+                                    qrcode_modal.open()
+                                }
                             }
                         }
 
-                        Qaterial.RawMaterialButton { //! Copy clipboard button
+                        Qaterial.RawMaterialButton
+                        {
                             implicitWidth: 45
                             backgroundColor: "transparent"
                             icon.source: Qaterial.Icons.contentCopy
+                            icon.color: DexTheme.foregroundColor
 
-                            onClicked: API.qt_utilities.copy_text_to_clipboard(rpc_pw.text)
+                            DefaultMouseArea
+                            {
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                onClicked:
+                                {
+                                    API.qt_utilities.copy_text_to_clipboard(seed_text.text)
+                                    app.notifyCopy(qsTr("Seed phrase"), qsTr("copied to clipboard"))
+                                }
+                            }                            
+                        }
+                    }
+                    RowLayout
+                    {
+                        Qaterial.RawMaterialButton
+                        {
+                            implicitWidth: 45
+                            backgroundColor: "transparent"
+                            icon.source: Qaterial.Icons.qrcodeScan
+                            icon.color: DexTheme.foregroundColor
+
+                            DefaultMouseArea
+                            {
+                                anchors.fill: parent
+                                hoverEnabled: true
+
+                                onClicked:
+                                {
+                                    qrcode_modal.qrcode_svg = API.qt_utilities.get_qrcode_svg_from_string(rpc_pw.text)
+                                    qrcode_modal.open()
+                                }
+                            }
+                        }
+
+                        Qaterial.RawMaterialButton
+                        {
+                            implicitWidth: 45
+                            backgroundColor: "transparent"
+                            icon.source: Qaterial.Icons.contentCopy
+                            icon.color: DexTheme.foregroundColor
+
+                            DefaultMouseArea
+                            {
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                onClicked: {
+                                    API.qt_utilities.copy_text_to_clipboard(rpc_pw.text)
+                                    app.notifyCopy(qsTr("RPC password"), qsTr("phrase key copied to clipboard"))
+                                }
+                            }
                         }
                     }
                 }
 
-                ColumnLayout {
+                ColumnLayout
+                {
                     // Seed
-                    DefaultText {
+                    DefaultText
+                    {
                         text: qsTr("Backup seed")
                         color: Style.modalValueColor
                         font.pixelSize: Style.textSizeSmall2
                     }
-                    DefaultText {
+                    DefaultText
+                    {
                         Layout.preferredWidth: 400
                         id: seed_text
                         font.pixelSize: Style.textSizeSmall1
                     }
 
                     // RPC Password
-                    DefaultText {
+                    DefaultText
+                    {
                         Layout.topMargin: 10
                         text: qsTr("RPC Password")
                         color: Style.modalValueColor
                         font.pixelSize: Style.textSizeSmall2
                     }
 
-                    DefaultText {
+                    DefaultText
+                    {
                         id: rpc_pw
                         font.pixelSize: Style.textSizeSmall3
                     }
@@ -214,7 +285,8 @@ BasicModal {
         }
 
         // Search input
-        DefaultTextField {
+        DefaultTextField
+        {
             Layout.fillWidth: true
             placeholderText: qsTr("Search a coin.")
             onTextChanged: portfolio_model.portfolio_proxy_mdl.setFilterFixedString(text)
@@ -222,7 +294,8 @@ BasicModal {
             Component.onDestruction: portfolio_model.portfolio_proxy_mdl.setFilterFixedString("")
         }
 
-        DexListView {
+        DexListView
+        {
             id: coins_list
 
             visible: false
@@ -232,95 +305,150 @@ BasicModal {
             Layout.fillHeight: true
             model: portfolio_mdl.portfolio_proxy_mdl
             
-            delegate: DefaultRectangle {
+            delegate: DefaultRectangle
+            {
                 height: seed_container.height
                 width: seed_container.width
 
-                RowLayout {
+                RowLayout
+                {
                     Layout.fillWidth: true
                     anchors.verticalCenter: parent.verticalCenter
 
-                    DefaultImage {
+                    DefaultImage
+                    {
                         Layout.leftMargin: 10
                         source: General.coinIcon(model.ticker)
                         Layout.preferredWidth: 32
                         Layout.preferredHeight: 32
                     }
 
-                    DefaultText {
+                    DefaultText
+                    {
                         Layout.preferredWidth: 100
                         Layout.leftMargin: 5
                         text: model.name
                         font.pixelSize: Style.textSizeSmall5
                     }
 
-                    ColumnLayout { // QR/Copy buttons
+                    // QR/Copy buttons
+                    ColumnLayout
+                    { 
                         spacing: 3
 
-                        RowLayout {
-                            Qaterial.RawMaterialButton {
+                        RowLayout
+                        {
+                            Qaterial.RawMaterialButton
+                            {
                                 Layout.topMargin: 2
                                 implicitWidth: 45
                                 backgroundColor: "transparent"
                                 icon.source: Qaterial.Icons.qrcodeScan
+                                icon.color: DexTheme.foregroundColor
 
-                                onClicked: {
-                                    qrcode_modal.qrcode_svg = API.qt_utilities.get_qrcode_svg_from_string(model.public_address)
-                                    qrcode_modal.open()
+                                DefaultMouseArea
+                                {
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+
+                                    onClicked:
+                                    {
+                                        qrcode_modal.qrcode_svg = API.qt_utilities.get_qrcode_svg_from_string(model.public_address)
+                                        qrcode_modal.open()
+                                    }
                                 }
                             }
 
-                            Qaterial.RawMaterialButton { //! Copy clipboard button
+                            // Copy clipboard button
+                            Qaterial.RawMaterialButton
+                            { 
                                 implicitWidth: 45
                                 backgroundColor: "transparent"
                                 icon.source: Qaterial.Icons.contentCopy
+                                icon.color: DexTheme.foregroundColor
 
-                                onClicked: API.qt_utilities.copy_text_to_clipboard(model.public_address)
+                                DefaultMouseArea
+                                {
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    onClicked:
+                                    {
+                                        API.qt_utilities.copy_text_to_clipboard(model.public_address)
+                                        app.notifyCopy(qsTr("%1 address").arg(model.ticker), qsTr("copied to clipboard"))
+                                    }
+                                }
                             }
                         }
 
-                        RowLayout {
-                            Qaterial.RawMaterialButton {
+                        RowLayout
+                        {
+                            Qaterial.RawMaterialButton
+                            {
                                 implicitWidth: 45
                                 backgroundColor: "transparent"
                                 icon.source: Qaterial.Icons.qrcodeScan
+                                icon.color: DexTheme.foregroundColor
 
-                                onClicked: {
-                                    qrcode_modal.qrcode_svg = API.qt_utilities.get_qrcode_svg_from_string(model.priv_key)
-                                    qrcode_modal.open()
+                                DefaultMouseArea
+                                {
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+
+                                    onClicked:
+                                    {
+                                        qrcode_modal.qrcode_svg = API.qt_utilities.get_qrcode_svg_from_string(model.priv_key)
+                                        qrcode_modal.open()
+                                    }
                                 }
                             }
 
-                            Qaterial.RawMaterialButton { //! Copy clipboard button
+                            // Copy clipboard button
+                            Qaterial.RawMaterialButton
+                            {
                                 implicitWidth: 45
                                 backgroundColor: "transparent"
                                 icon.source: Qaterial.Icons.contentCopy
+                                icon.color: DexTheme.foregroundColor
 
-                                onClicked: API.qt_utilities.copy_text_to_clipboard(model.priv_key)
+                                DefaultMouseArea
+                                {
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    onClicked: {
+                                        API.qt_utilities.copy_text_to_clipboard(model.priv_key)
+                                        app.notifyCopy(qsTr("%1 private key").arg(model.ticker), qsTr("copied to clipboard"))
+                                    }
+                                }             
                             }
                         }
                     }
 
-                    ColumnLayout { // Addresses
-                        DefaultText {
+                    // Addresses
+                    ColumnLayout
+                    { 
+                        DefaultText
+                        {
                             text: qsTr("Public Address")
                             color: Style.modalValueColor
                             font.pixelSize: Style.textSizeSmall2
                         }
 
-                        DefaultText {
+                        DefaultText
+                        {
                             text: model.public_address
                             font.pixelSize: Style.textSizeSmall3
                         }
 
-                        DefaultText {
+                        DefaultText
+                        {
                             Layout.topMargin: 10
                             text: qsTr("Private Key")
                             color: Style.modalValueColor
                             font.pixelSize: Style.textSizeSmall2
                         }
 
-                        DefaultText {
+                        DefaultText
+                        {
                             text: model.priv_key
                             font.pixelSize: Style.textSizeSmall3
                         }
@@ -330,20 +458,24 @@ BasicModal {
         }
 
         // Buttons
-        footer: [
-            DefaultButton {
+        footer:
+        [
+            DefaultButton
+            {
                 text: qsTr("Close")
                 Layout.fillWidth: true
                 onClicked: root.close()
             }
         ]
 
-        ModalLoader {
+        ModalLoader
+        {
             id: qrcode_modal
 
             property string qrcode_svg
 
-            sourceComponent: Popup {
+            sourceComponent: Popup
+            {
                 id: popup
 
                 x: (root.width - width) / 2
@@ -351,7 +483,8 @@ BasicModal {
 
                 onClosed: qrcode_svg = ""
 
-                background: Image {
+                background: Image
+                {
                     source: qrcode_svg
 
                     sourceSize.width: 200


### PR DESCRIPTION
- recolor qrcode / copy icons so they are visible in light/dark mode.
- fix add pointer cursor on hover over icons
- add "copied to clipboard" notification on click
- change password field to use DexAppPasswordField so show/hide button color is visible in dark/light mode.

Resolves #7 in https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1427#issuecomment-968682835
