### PR TITLE
use DefaultImage

### DIFF
--- a/atomic_defi_design/Dex/Components/SearchField.qml
+++ b/atomic_defi_design/Dex/Components/SearchField.qml
@@ -16,7 +16,7 @@ Rectangle
     color: Dex.CurrentTheme.accentColor
     radius: 18
 
-    Image
+    DefaultImage
     {
         id: _searchIcon
         anchors.left: parent.left

--- a/atomic_defi_design/Dex/Exchange/Trade/BestOrder/ListDelegate.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/BestOrder/ListDelegate.qml
@@ -45,7 +45,7 @@ Item {
             Layout.preferredWidth: 130
             leftPadding: -10
             spacing: 5
-            Image {
+            DefaultImage {
                 source: Constants.General.coinIcon(coin)
                 width: 20
                 height: 20

--- a/atomic_defi_design/Dex/Exchange/Trade/SimpleView/Trade.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/SimpleView/Trade.qml
@@ -239,7 +239,7 @@ ClipRRect // Trade Card
                     elide: Text.ElideRight
                     color: DexTheme.foregroundColorLightColor1
 
-                    DexImage
+                    DefaultImage
                     {
                         id: _fromBalanceIcon
                         width: 16
@@ -672,7 +672,7 @@ ClipRRect // Trade Card
                     }
                 }
 
-                Image // Alert
+                DefaultImage // Alert
                 {
                     id: _swapAlert
 

--- a/atomic_defi_design/Dex/Portfolio/AssetsList.qml
+++ b/atomic_defi_design/Dex/Portfolio/AssetsList.qml
@@ -116,8 +116,7 @@ Dex.DefaultListView
             {
                 Layout.preferredWidth: _assetNameColumnWidth
 
-                Image
-                {
+                Dex.DefaultImage {
                     id: assetImage
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.left: parent.left
@@ -203,16 +202,14 @@ Dex.DefaultListView
             {
                 Layout.preferredWidth: _assetProviderColumnWidth
 
-                Image // Price Provider Icon.
-                {
+                Dex.DefaultImage {
                     id: priceProviderIcon
-
                     enabled: priceProvider !== "unknown"
                     visible: enabled
                     anchors.centerIn: parent
+                    source: enabled ? Dex.General.providerIcon(priceProvider) : ""
                     width: 16
                     height: 16
-                    source: enabled ? Dex.General.providerIcon(priceProvider) : ""
 
                     Dex.DefaultMouseArea
                     {

--- a/atomic_defi_design/Dex/Sidebar/Top.qml
+++ b/atomic_defi_design/Dex/Sidebar/Top.qml
@@ -48,7 +48,7 @@ MouseArea
         to: 1
     }
 
-    Image
+    DefaultImage
     {
         id: dexLogo
         anchors.horizontalCenter: parent.horizontalCenter

--- a/atomic_defi_design/Dex/Wallet/Main.qml
+++ b/atomic_defi_design/Dex/Wallet/Main.qml
@@ -311,7 +311,7 @@ Item
                     }
                 }
 
-                Image
+                DefaultImage
                 {
                     visible: API.app.wallet_pg.send_availability_state !== ""
 

--- a/atomic_defi_design/Dex/Wallet/ReceiveModal.qml
+++ b/atomic_defi_design/Dex/Wallet/ReceiveModal.qml
@@ -30,7 +30,7 @@ BasicModal {
             }
         }
 
-        Image {
+        DefaultImage {
             Layout.alignment: Qt.AlignHCenter
 
             source: current_ticker_infos.qrcode_address

--- a/atomic_defi_design/Dex/main.qml
+++ b/atomic_defi_design/Dex/main.qml
@@ -154,7 +154,7 @@ DexWindow
         layoutDirection: isOsx ? Qt.RightToLeft : Qt.LeftToRight
         spacing: 5
 
-        Image
+        DefaultImage
         {
             source: "qrc:/assets/images/dex-tray-icon.png"
             width: 15


### PR DESCRIPTION
`DefaultImage` extends image with
```
    mipmap: true
    fillMode: Image.PreserveAspectFit
```
So does `DexImage`, though it was only in use in one place. I've updated all references of `Image` and `DexImage` to use `DefaultImage`

closes: https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1351