### PR TITLE
fix overlapping table header and text

### DIFF
--- a/atomic_defi_design/Dex/Exchange/Trade/SimpleView/SubBestOrder.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/SimpleView/SubBestOrder.qml
@@ -50,7 +50,6 @@ DefaultListView
     {
         width: _rowWidth
         height: _rowHeight
-        radius: 5
         z: 2
         color: Dex.CurrentTheme.floatingBackgroundColor
 

--- a/atomic_defi_design/Dex/Exchange/Trade/SimpleView/SubBestOrder.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/SimpleView/SubBestOrder.qml
@@ -59,7 +59,8 @@ DefaultListView
         {
             anchors.verticalCenter: parent.verticalCenter
             anchors.fill: parent
-            DexLabel             // "Token" Header
+            spacing: 2
+            DefaultText             // "Token" Header
             {
                 Layout.preferredWidth: _tokenColumnSize
                 text: qsTr("Token")
@@ -68,7 +69,7 @@ DefaultListView
                 font.pixelSize: 12
                 font.weight: Font.Bold
             }
-            DexLabel             // "Available Quantity" Header
+            DefaultText             // "Available Quantity" Header
             {
                 Layout.preferredWidth: _quantityColumnSize
                 text: qsTr("Available Quantity")
@@ -77,7 +78,7 @@ DefaultListView
                 font.pixelSize: 12
                 font.weight: Font.Bold
             }
-            DexLabel             // "Available Quantity (in BASE)" header
+            DefaultText             // "Available Quantity (in BASE)" header
             {
                 Layout.preferredWidth: _quantityInBaseColumnSize
                 text: qsTr("Available Quantity (in %1)").arg(currentLeftToken)
@@ -86,7 +87,7 @@ DefaultListView
                 font.pixelSize: 12
                 font.weight: Font.Bold
             }
-            DexLabel             // "Fiat Volume" column header
+            DefaultText             // "Fiat Volume" column header
             {
                 Layout.preferredWidth: _fiatVolumeColumnSize
                 text: qsTr("Fiat Volume")
@@ -95,7 +96,7 @@ DefaultListView
                 font.pixelSize: 12
                 font.weight: Font.Bold
             }
-            DexLabel             // "CEX Rate" column header
+            DefaultText             // "CEX Rate" column header
             {
                 Layout.preferredWidth: _cexRateColumnSize
                 text: qsTr("CEX Rate")

--- a/atomic_defi_design/Dex/Exchange/Trade/SimpleView/SubCoinSelector.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/SimpleView/SubCoinSelector.qml
@@ -33,7 +33,6 @@ DefaultListView
     {
         width: _rowWidth
         height: _rowHeight
-        radius: 5
         z: 2
         color: Dex.CurrentTheme.floatingBackgroundColor
 

--- a/atomic_defi_design/Dex/Exchange/Trade/SimpleView/SubCoinSelector.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/SimpleView/SubCoinSelector.qml
@@ -27,11 +27,14 @@ DefaultListView
     headerPositioning: ListView.OverlayHeader
     reuseItems: true
     cacheBuffer: 40
+    clip: true
 
     header: DefaultRectangle
     {
         width: _rowWidth
         height: _rowHeight
+        radius: 5
+        z: 2
         color: Dex.CurrentTheme.floatingBackgroundColor
 
         RowLayout                   // Coins Columns Name
@@ -45,7 +48,7 @@ DefaultListView
 
                 Layout.preferredWidth: _tokenColumnSize
                 text: qsTr("Token")
-                font.family: Style.font_family
+                font.family: Constants.Style.font_family
                 font.bold: true
                 font.pixelSize: 12
                 font.weight: Font.Bold
@@ -66,7 +69,7 @@ DefaultListView
 
                 Layout.fillWidth: true
                 text: qsTr("Balance")
-                font.family: Style.font_family
+                font.family: Constants.Style.font_family
                 font.bold: true
                 font.pixelSize: 12
                 font.weight: Font.Bold
@@ -87,7 +90,7 @@ DefaultListView
             	property bool asc: true
 
                 text: qsTr("Balance Fiat")
-                font.family: Style.font_family
+                font.family: Constants.Style.font_family
                 font.bold: true
                 font.pixelSize: 12
                 font.weight: Font.Bold


### PR DESCRIPTION
- added clipping to header
- removed rounding (on scroll you could sometimes see row item text in corner)
- `DexLabel` -> `DefaultText`

Before:
![image](https://user-images.githubusercontent.com/35845239/146631772-24fdeb18-4473-4fb1-9b53-f57ba557acd5.png)

After:
![image](https://user-images.githubusercontent.com/35845239/146631804-807dbb8e-5319-4d65-9347-232eeffbdb6b.png)

