### PR TITLE
undo llvm patch

### DIFF
--- a/ci_tools_atomic_dex/ci_scripts/linux_script.sh
+++ b/ci_tools_atomic_dex/ci_scripts/linux_script.sh
@@ -31,7 +31,7 @@ sudo apt-get install build-essential \
 # get llvm
 wget https://apt.llvm.org/llvm.sh
 chmod +x llvm.sh
-sudo ./llvm.sh 12 all
+sudo ./llvm.sh 12
 # set clang version
 sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 777
 sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 777


### PR DESCRIPTION
llvm seems to have fixed the issue which made our CI fail. The patch applied while it was broken I think is inflating the linux archive size, so probably best removed.