### PR TITLE
add missing fields for DOI

### DIFF
--- a/assets/config/0.5.4-coins.json
+++ b/assets/config/0.5.4-coins.json
@@ -2177,7 +2177,9 @@
     "explorer_url": [
       "https://explorer.doichain.org/"
     ],
-    "type": "UTXO"
+    "type": "UTXO",
+    "active": false,
+    "currently_enabled": false
   },
   "DOGE-BEP20": {
     "coin": "DOGE-BEP20",


### PR DESCRIPTION
@inspiraluna seems these electrums are also non-responsive.
I get no response from the below:
`echo '{"method":"blockchain.transaction.get","params":["0d217f66bd512205f260df3b3955390e51c09c8fa86f96c33d1e0a106596aa7b", true],"id":"test"}' | nc pink-deer-69.doi.works 50002 -i 1 | jq .` for the provided urls