### PR TITLE
replace tooltip

### DIFF
--- a/atomic_defi_design/Dex/Wallet/SidebarItemDelegate.qml
+++ b/atomic_defi_design/Dex/Wallet/SidebarItemDelegate.qml
@@ -66,19 +66,8 @@ GradientRectangle {
             Layout.preferredWidth: 80
             font: DexTypo.caption
             wrapMode: DexLabel.WordWrap
-            text_value: ticker
+            text_value: mouse_area.containsMouse ? name.replace(" (TESTCOIN)", "") : ticker
             color: DexTheme.foregroundColor
-        }
-
-        DefaultTooltip {
-            visible: mouse_area.containsMouse
-
-            contentItem: ColumnLayout {
-                DefaultText {
-                    text_value: name.replace(" (TESTCOIN)", "")
-                    font.pixelSize: Constants.Style.textSizeSmall4
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Potential fix for https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/400

Replaces tooltip with mouseover changing ticker to name

https://user-images.githubusercontent.com/35845239/152854623-a42e1917-86bb-4210-a0b8-751384762089.mp4


