### PR TITLE
Add wallet only label

### DIFF
--- a/atomic_defi_design/Dex/Components/CoinTypeTag.qml
+++ b/atomic_defi_design/Dex/Components/CoinTypeTag.qml
@@ -9,14 +9,14 @@ AnimatedRectangle {
     height: type_tag.font.pixelSize * 1.5
     width: type_tag.width + 8
 
-    color: Style.getCoinTypeColor(model.type)
+    color: Style.getCoinTypeColor(type)
 
     DexLabel {
         id: type_tag
         anchors.verticalCenter: parent.verticalCenter
         anchors.horizontalCenter: parent.horizontalCenter
         text: type
-        color: Style.getCoinTypeTextColor(model.type)
+        color: Style.getCoinTypeTextColor(type)
         font: DexTypo.overLine
     }
 }

--- a/atomic_defi_design/Dex/Constants/Style.qml
+++ b/atomic_defi_design/Dex/Constants/Style.qml
@@ -240,6 +240,7 @@ QtObject {
             case 'ERC-20':      return getCoinColor("ETH")
             case 'QRC-20':      return getCoinColor("QTUM")
             case 'Smart Chain': return getCoinColor("KMD")
+            case 'WALLET ONLY': return "#4D4D4D"
             case 'UTXO':        return getCoinColor("BTC")
             case 'BEP-20':      return getCoinColor("BNB")
             case 'SLP':         return getCoinColor("BCH")

--- a/atomic_defi_design/Dex/Wallet/EnableCoinModal.qml
+++ b/atomic_defi_design/Dex/Wallet/EnableCoinModal.qml
@@ -135,42 +135,51 @@ BasicModal
                     }
                 }
 
-                // Icon
-                DefaultImage
-                {
-                    id: icon
+                RowLayout {
                     anchors.left: parent.right
-                    anchors.leftMargin: 8
-                    anchors.verticalCenter: parent.verticalCenter
-                    source: General.coinIcon(model.ticker)
-                    width: 18
-                    height: 18
+                    spacing:6
+                    Layout.alignment: Qt.AlignVCenter
 
+                    // Icon
+                    DefaultImage
+                    {
+                        id: icon
+                        Layout.leftMargin: 8
+                        Layout.alignment: Qt.AlignVCenter
+                        source: General.coinIcon(model.ticker)
+                        Layout.preferredWidth: 18
+                        Layout.preferredHeight: 18
+                    }
                     DefaultText
                     {
-                        anchors.left: parent.right
-                        anchors.leftMargin: 4
-                        anchors.verticalCenter: parent.verticalCenter
+                        Layout.leftMargin: 4
+                        Layout.alignment: Qt.AlignVCenter
                         text: model.name + " (" + model.ticker + ")"
+                    }
+                    CoinTypeTag
+                    {
+                        id: typeTag
+                        Layout.leftMargin: 6
+                        Layout.alignment: Qt.AlignVCenter
+                        type: model.type
+                    }
 
-                        CoinTypeTag
-                        {
-                            id: typeTag
-                            anchors.left: parent.right
-                            anchors.leftMargin: 6
-                            anchors.verticalCenter: parent.verticalCenter
-                            type: model.type
-                        }
+                    CoinTypeTag
+                    {
+                        Layout.leftMargin: 6
+                        Layout.alignment: Qt.AlignVCenter
+                        enabled: General.isIDO(model.ticker)
+                        visible: enabled
+                        type: "IDO"
+                    }
 
-                        CoinTypeTag
-                        {
-                            anchors.left: typeTag.right
-                            anchors.leftMargin: 6
-                            anchors.verticalCenter: parent.verticalCenter
-                            enabled: General.isIDO(model.ticker)
-                            visible: enabled
-                            type: "IDO"
-                        }
+                    CoinTypeTag
+                    {
+                        Layout.leftMargin: 6
+                        Layout.alignment: Qt.AlignVCenter
+                        enabled: API.app.portfolio_pg.global_cfg_mdl.get_coin_info(model.ticker).is_wallet_only
+                        visible: enabled
+                        type: "WALLET ONLY"
                     }
                 }
             }

--- a/atomic_defi_design/Dex/Wallet/EnableCoinModal.qml
+++ b/atomic_defi_design/Dex/Wallet/EnableCoinModal.qml
@@ -136,9 +136,9 @@ BasicModal
                 }
 
                 RowLayout {
+                    anchors.verticalCenter: parent.verticalCenter
                     anchors.left: parent.right
                     spacing:6
-                    Layout.alignment: Qt.AlignVCenter
 
                     // Icon
                     DefaultImage

--- a/atomic_defi_design/Dex/Wallet/Main.qml
+++ b/atomic_defi_design/Dex/Wallet/Main.qml
@@ -59,11 +59,12 @@ Item
             Layout.leftMargin: layout_margin
             Layout.rightMargin: layout_margin
 
-            RowLayout {
-
+            RowLayout
+            {
                 anchors.fill: parent
 
-                RowLayout {
+                RowLayout
+                {
                     Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
                     Layout.fillWidth: true
                     Layout.fillHeight: true
@@ -136,20 +137,24 @@ Item
 
                     Item { Layout.fillWidth: true }
 
-                    ColumnLayout {
+                    ColumnLayout
+                    {
                         visible: false //current_ticker_infos.segwit_supported
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                         spacing: 2
-                        DexLabel {
+                        DexLabel
+                        {
                             text_value: qsTr("Segwit")
                             Layout.alignment: Qt.AlignLeft
                             font.pixelSize: headerTitleFont
                             color: headerTitleColor
                         }
-                        DefaultSwitch {
+                        DefaultSwitch
+                        {
                             id: segwitSwitch
                             Layout.alignment: Qt.AlignVCenter
-                            onToggled: {
+                            onToggled:
+                            {
                                 if(parseFloat(current_ticker_infos.balance) > 0) {
                                      Qaterial.DialogManager.showDialog({
                                         title: qsTr("Confirmation"),
@@ -185,7 +190,6 @@ Item
                                     app.segwit_on = true
                                     API.app.wallet_pg.post_switch_address_mode(!current_ticker_infos.is_segwit_on)
                                 }
-
                             }
                         }
                     }
@@ -193,10 +197,8 @@ Item
                     Connections
                     {
                         target: API.app.wallet_pg
-                        function onTickerInfosChanged()
-                        {
-                            if (segwitSwitch.checked != current_ticker_infos.is_segwit_on)
-                            {
+                        function onTickerInfosChanged() {
+                            if (segwitSwitch.checked != current_ticker_infos.is_segwit_on) {
                                 segwitSwitch.checked = current_ticker_infos.is_segwit_on
                             }
                         }
@@ -380,13 +382,10 @@ Item
             Layout.alignment: Qt.AlignHCenter
             spacing: 25
 
-            Item { Layout.fillWidth: true }
-            Item { Layout.fillWidth: true }
-
             Item
             {
-                Layout.preferredWidth: 150
-                Layout.preferredHeight: 40
+                Layout.preferredWidth: 180
+                Layout.preferredHeight: 48
 
                 // Send Button
                 DexAppButton
@@ -394,7 +393,7 @@ Item
                     enabled: API.app.wallet_pg.send_available
 
                     anchors.fill: parent
-                    radius: 12
+                    radius: 18
 
                     label.text: qsTr("Send")
                     label.font.pixelSize: 16
@@ -480,7 +479,8 @@ Item
                                     close()
                                 }
                             }
-                            DefaultButton {
+                            DefaultButton
+                            {
                                 Layout.fillWidth: true
                                 text: qsTr("No")
                                 onClicked: close()
@@ -503,14 +503,12 @@ Item
                 sourceComponent: CannotEnableCoinModal { coin_to_enable_ticker: API.app.wallet_pg.ticker_infos.fee_ticker }
             }
 
-            Item { Layout.fillWidth: true }
-
             // Receive Button
             DexAppButton
             {
-                Layout.preferredWidth: 150
-                Layout.preferredHeight: 40
-                radius: 12
+                Layout.preferredWidth: 180
+                Layout.preferredHeight: 48
+                radius: 18
 
                 label.text: qsTr("Receive")
                 label.font.pixelSize: 16
@@ -534,20 +532,18 @@ Item
                 sourceComponent: ReceiveModal {}
             }
 
-            Item { Layout.fillWidth: true }
-
             // Swap Button
             Item
             {
                 visible: !is_dex_banned
-                Layout.preferredWidth: 150
-                Layout.preferredHeight: 40
+                Layout.preferredWidth: 180
+                Layout.preferredHeight: 48
 
                 DexAppButton
                 {
                     enabled: !API.app.portfolio_pg.global_cfg_mdl.get_coin_info(api_wallet_page.ticker).is_wallet_only
                     anchors.fill: parent
-                    radius: 12
+                    radius: 18
 
                     // Inner text.
                     label.text: qsTr("Swap")
@@ -609,15 +605,13 @@ Item
                 }
             }
 
-            Item {
-                Layout.fillWidth: true
-                visible: current_ticker_infos.is_claimable && !API.app.is_pin_cfg_enabled()
-            }
+            Item { Layout.fillWidth: true }
 
             // Rewards Button
-            Item {
-                Layout.preferredWidth: 150
-                Layout.preferredHeight: 40
+            Item
+            {
+                Layout.preferredWidth: 180
+                Layout.preferredHeight: 48
                 visible: current_ticker_infos.is_claimable && !API.app.is_pin_cfg_enabled()
 
                 Item { Layout.fillWidth: true }
@@ -625,7 +619,7 @@ Item
                 DexAppButton
                 {
                     text: qsTr("Rewards")
-                    radius: 12
+                    radius: 18
                     font.pixelSize: 16
                     anchors.fill: parent
                     enabled: parseFloat(current_ticker_infos.balance) > 0
@@ -643,21 +637,17 @@ Item
                 }
             }
 
-            Item {
-                Layout.fillWidth: true
-                visible: enabled && current_ticker_infos.is_smartchain_test_coin
-            }
-
             // Faucet Button
-            Item {
-                Layout.preferredWidth: 150
-                Layout.preferredHeight: 40
+            Item
+            {
+                Layout.preferredWidth: 180
+                Layout.preferredHeight: 48
                 visible: enabled && current_ticker_infos.is_smartchain_test_coin
 
                 DexAppButton
                 {
                     text: qsTr("Faucet")
-                    radius: 12
+                    radius: 18
                     font.pixelSize: 16
                     anchors.fill: parent
                     onClicked: api_wallet_page.claim_faucet()
@@ -668,13 +658,11 @@ Item
             Component.onDestruction: api_wallet_page.claimingFaucetRpcDataChanged.disconnect(onClaimFaucetRpcResultChanged)
             function onClaimFaucetRpcResultChanged() { claimFaucetResultModal.open() }
 
-            ModalLoader {
+            ModalLoader
+            {
                 id: claimFaucetResultModal
                 sourceComponent: ClaimFaucetResultModal {}
             }
-
-            Item { Layout.fillWidth: true }
-            Item { Layout.fillWidth: true }
         }
 
         // Price Graph
@@ -818,27 +806,32 @@ Item
         }
 
         // Transactions or loading
-        Item {
+        Item
+        {
             id: loading_tx
             visible: current_ticker_infos.tx_state === "InProgress"
             Layout.alignment: Qt.AlignHCenter
             Layout.fillWidth: true
             implicitHeight: 100
 
-            ColumnLayout {
+            ColumnLayout
+            {
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.verticalCenter: parent.verticalCenter
-                DexLabel {
+                DexLabel
+                {
                     text_value: qsTr("Loading")
                     Layout.alignment: Qt.AlignHCenter
                     font.pixelSize: Style.textSize2
                 }
 
-                DefaultBusyIndicator {
+                DefaultBusyIndicator
+                {
                     Layout.alignment: Qt.AlignHCenter
                 }
 
-                DexLabel {
+                DexLabel
+                {
                     text_value: General.isTokenType(current_ticker_infos.type) ?
                                 (qsTr("Scanning blocks for TX History...") + " " + loadingPercentage(current_ticker_infos.blocks_left)) :
                                 (qsTr("Syncing TX History...") + " " + loadingPercentage(current_ticker_infos.transactions_left))
@@ -849,13 +842,15 @@ Item
         }
 
         // Separator line
-        HorizontalLine {
+        HorizontalLine
+        {
             visible: loading_tx.visible && transactions_mdl.length > 0
             width: 720
             Layout.alignment: Qt.AlignHCenter
         }
 
-        Rectangle {
+        Rectangle
+        {
             id: transactions_bg
             Layout.fillWidth: true
             Layout.fillHeight: true
@@ -868,7 +863,8 @@ Item
             color: Dex.CurrentTheme.floatingBackgroundColor
             radius: 22
 
-            ClipRRect {
+            ClipRRect
+            {
                 radius: parent.radius
                 width: transactions_bg.width
                 height: transactions_bg.height
@@ -884,14 +880,16 @@ Item
                     }
                 }
 
-                DefaultText {
+                DefaultText
+                {
                     anchors.centerIn: parent
                     visible: current_ticker_infos.tx_state !== "InProgress" && transactions_mdl.length === 0
                     text_value: api_wallet_page.tx_fetching_busy ? (qsTr("Refreshing") + "...") : qsTr("No transactions")
                     font.pixelSize: Style.textSize
                 }
 
-                Transactions {
+                Transactions
+                {
                     width: parent.width
                     height: parent.height
                     model: transactions_mdl.proxy_mdl
@@ -899,7 +897,8 @@ Item
             }
         }
 
-        RowLayout {
+        RowLayout
+        {
             id: fetching_text_row
             visible: api_wallet_page.tx_fetching_busy
             Layout.preferredHeight: fetching_text.font.pixelSize * 1.5
@@ -909,13 +908,15 @@ Item
 
             Layout.alignment: Qt.AlignHCenter
             spacing: 10
-            DefaultBusyIndicator {
+            DefaultBusyIndicator
+            {
                 Layout.alignment: Qt.AlignVCenter
                 Layout.preferredWidth: Style.textSizeSmall3
                 Layout.preferredHeight: Layout.preferredWidth
             }
 
-            DefaultText {
+            DefaultText
+            {
                 id: fetching_text
                 Layout.alignment: Qt.AlignVCenter
                 text_value: qsTr("Fetching transactions") + "..."

--- a/atomic_defi_design/Dex/Wallet/Main.qml
+++ b/atomic_defi_design/Dex/Wallet/Main.qml
@@ -371,8 +371,7 @@ Item
             }
         }
 
-
-        // Address Book, Send, Receive buttons
+        // Buttons
         RowLayout
         {
             Layout.leftMargin: layout_margin
@@ -380,21 +379,27 @@ Item
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignHCenter
             spacing: 25
+
+            Item { Layout.fillWidth: true }
+            Item { Layout.fillWidth: true }
+
             Item
             {
-                Layout.preferredWidth: 199
-                Layout.preferredHeight: 48
+                Layout.preferredWidth: 150
+                Layout.preferredHeight: 40
+
+                // Send Button
                 DexAppButton
                 {
                     enabled: API.app.wallet_pg.send_available
 
                     anchors.fill: parent
-                    radius: 18
+                    radius: 12
 
                     label.text: qsTr("Send")
                     label.font.pixelSize: 16
                     content.anchors.left: content.parent.left
-                    content.anchors.leftMargin: enabled ? 23 : 60
+                    content.anchors.leftMargin: enabled ? 23 : 48
 
                     onClicked:
                     {
@@ -412,6 +417,7 @@ Item
                     }
                 }
 
+                // Send button error icon
                 DefaultImage
                 {
                     visible: API.app.wallet_pg.send_availability_state !== ""
@@ -497,11 +503,14 @@ Item
                 sourceComponent: CannotEnableCoinModal { coin_to_enable_ticker: API.app.wallet_pg.ticker_infos.fee_ticker }
             }
 
+            Item { Layout.fillWidth: true }
+
+            // Receive Button
             DexAppButton
             {
-                Layout.preferredWidth: 199
-                Layout.preferredHeight: 48
-                radius: 18
+                Layout.preferredWidth: 150
+                Layout.preferredHeight: 40
+                radius: 12
 
                 label.text: qsTr("Receive")
                 label.font.pixelSize: 16
@@ -525,77 +534,134 @@ Item
                 sourceComponent: ReceiveModal {}
             }
 
-            DexAppButton
-            {
-                visible: !is_dex_banned
-
-                Layout.preferredWidth: 199
-                Layout.preferredHeight: 48
-                radius: 18
-
-                // Inner text.
-                label.text: qsTr("Swap")
-                label.font.pixelSize: 16
-                content.anchors.left: content.parent.left
-                content.anchors.leftMargin: 23
-
-                onClicked: onClickedSwap()
-
-                Row
-                {
-                    anchors.verticalCenter: parent.verticalCenter
-                    anchors.right: parent.right
-                    anchors.rightMargin: arrow_send.anchors.rightMargin
-                    spacing: 2
-                    
-                    Arrow
-                    {
-                        up: true
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
-
-                    Arrow
-                    {
-                        up: false
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
-                }
-            }
-
             Item { Layout.fillWidth: true }
 
-            DexAppButton
+            // Swap Button
+            Item
             {
-                text: qsTr("Rewards")
+                visible: !is_dex_banned
                 Layout.preferredWidth: 150
-                Layout.preferredHeight: 48
-                radius: 18
-                font.pixelSize: 16
-                visible: current_ticker_infos.is_claimable && !API.app.is_pin_cfg_enabled()
-                enabled: parseFloat(current_ticker_infos.balance) > 0
-                onClicked:
+                Layout.preferredHeight: 40
+
+                DexAppButton
                 {
-                    claimRewardsModal.open()
-                    claimRewardsModal.item.prepareClaimRewards()
+                    enabled: !API.app.portfolio_pg.global_cfg_mdl.get_coin_info(api_wallet_page.ticker).is_wallet_only
+                    anchors.fill: parent
+                    radius: 12
+
+                    // Inner text.
+                    label.text: qsTr("Swap")
+                    label.font.pixelSize: 16
+                    content.anchors.left: content.parent.left
+                    content.anchors.leftMargin: enabled ? 23 : 48
+
+                    onClicked: onClickedSwap()
+
+                    Row
+                    {
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.right: parent.right
+                        anchors.rightMargin: arrow_send.anchors.rightMargin
+                        spacing: 2
+
+                        Arrow
+                        {
+                            up: true
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+
+                        Arrow
+                        {
+                            up: false
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+                }
+
+                // Send button error icon
+                DefaultImage
+                {
+                    visible: API.app.portfolio_pg.global_cfg_mdl.get_coin_info(api_wallet_page.ticker).is_wallet_only
+
+                    anchors.left: parent.left
+                    anchors.leftMargin: 14
+                    anchors.verticalCenter: parent.verticalCenter
+                    source: Qaterial.Icons.alert
+
+                    DefaultColorOverlay
+                    {
+                        anchors.fill: parent
+                        source: parent
+                        color: "yellow"
+                    }
+                    MouseArea
+                    {
+                        id: swap_alert_mouse_area
+                        anchors.fill: parent
+                        hoverEnabled: true
+                    }
+
+                    DefaultTooltip
+                    {
+                        visible: swap_alert_mouse_area.containsMouse
+                        text: api_wallet_page.ticker + qsTr(" is wallet only")
+                    }
                 }
             }
 
-            ModalLoader
-            {
-                id: claimRewardsModal
-                sourceComponent: ClaimRewardsModal {}
+            Item {
+                Layout.fillWidth: true
+                visible: current_ticker_infos.is_claimable && !API.app.is_pin_cfg_enabled()
             }
 
-            DexAppButton
-            {
-                text: qsTr("Faucet")
+            // Rewards Button
+            Item {
                 Layout.preferredWidth: 150
-                Layout.preferredHeight: 48
-                radius: 18
-                font.pixelSize: 16
+                Layout.preferredHeight: 40
+                visible: current_ticker_infos.is_claimable && !API.app.is_pin_cfg_enabled()
+
+                Item { Layout.fillWidth: true }
+
+                DexAppButton
+                {
+                    text: qsTr("Rewards")
+                    radius: 12
+                    font.pixelSize: 16
+                    anchors.fill: parent
+                    enabled: parseFloat(current_ticker_infos.balance) > 0
+                    onClicked:
+                    {
+                        claimRewardsModal.open()
+                        claimRewardsModal.item.prepareClaimRewards()
+                    }
+                }
+
+                ModalLoader
+                {
+                    id: claimRewardsModal
+                    sourceComponent: ClaimRewardsModal {}
+                }
+            }
+
+            Item {
+                Layout.fillWidth: true
+                visible: enabled && current_ticker_infos.is_smartchain_test_coin
+            }
+
+            // Faucet Button
+            Item {
+                Layout.preferredWidth: 150
+                Layout.preferredHeight: 40
                 visible: enabled && current_ticker_infos.is_smartchain_test_coin
 
-                onClicked: api_wallet_page.claim_faucet()
+                DexAppButton
+                {
+                    text: qsTr("Faucet")
+                    radius: 12
+                    font.pixelSize: 16
+                    anchors.fill: parent
+                    onClicked: api_wallet_page.claim_faucet()
+                }
             }
 
             Component.onCompleted: api_wallet_page.claimingFaucetRpcDataChanged.connect(onClaimFaucetRpcResultChanged)
@@ -606,6 +672,9 @@ Item
                 id: claimFaucetResultModal
                 sourceComponent: ClaimFaucetResultModal {}
             }
+
+            Item { Layout.fillWidth: true }
+            Item { Layout.fillWidth: true }
         }
 
         // Price Graph

--- a/src/core/atomicdex/models/qt.global.coins.cfg.model.cpp
+++ b/src/core/atomicdex/models/qt.global.coins.cfg.model.cpp
@@ -43,6 +43,7 @@ namespace
             {"has_parent_fees_ticker", coin.has_parent_fees_ticker},
             {"is_testnet", coin.is_testnet.value_or(false)},
             {"is_erc_family", coin.is_erc_family},
+            {"is_wallet_only", coin.wallet_only},
             {"fees_ticker", QString::fromStdString(coin.fees_ticker)}};
         return j;
     }


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1343

Tag has been added in enable modal
![image](https://user-images.githubusercontent.com/35845239/155232481-71f4e094-3a5f-47ed-820a-d26408bde299.png)

Disabled swap button with tooltip when coin is wallet only
![image](https://user-images.githubusercontent.com/35845239/155232717-2cf66f8a-d0f4-46fb-8a7d-1b67673b54da.png)

Do we want this tagging alongside the ticker on portfolio? Or in wallet header section? Not really sure where to slot it in.