### PR TITLE
no notification if coin already enabled

### DIFF
--- a/atomic_defi_design/Dex/Dashboard/NotificationsModal.qml
+++ b/atomic_defi_design/Dex/Dashboard/NotificationsModal.qml
@@ -268,6 +268,12 @@ DexPopup
     readonly property string check_internet_connection_text: qsTr("Please check your internet connection (e.g. VPN service or firewall might block it).")
     function onEnablingCoinFailedStatus(coin, error, human_date, timestamp)
     {
+        // Ignore if coin already enabled (e.g. parent chain in batch)
+        if (error.search("already initialized") > -1) {
+            console.log("Ignoring onEnablingCoinFailedStatus event because " + coin + " already enabled.")
+            return
+        }
+
         // Check if there is mismatch error, ignore this one
         for (let n of notifications_list)
         {


### PR DESCRIPTION
Currently if batch selecting tokens and parent chain from enable menu, often this error will appear - 
![image](https://user-images.githubusercontent.com/35845239/155750981-ea1df73a-132e-4e61-9476-a2186e625795.png)

This PR ignores "already initialized" error and makes no notification for it.

Related to https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1192 which was already resolved.