### PR TITLE
make smtf-v2 active by default on smartdex

### DIFF
--- a/assets/config/0.5.4-coins.json
+++ b/assets/config/0.5.4-coins.json
@@ -5608,7 +5608,7 @@
       "https://bscscan.com/"
     ],
     "type": "BEP-20",
-    "active": false,
+    "active": true,
     "currently_enabled": false
   },
   "SOULJA": {


### PR DESCRIPTION
We should be extra careful on next sync to not revert such things (default coins, tos, etc)