### PR TITLE
remove bad PRUX electrum

### DIFF
--- a/assets/config/0.5.4-coins.json
+++ b/assets/config/0.5.4-coins.json
@@ -5433,11 +5433,7 @@
       {
         "url": "electrumx.live:50010",
         "protocol": "TCP"
-      },
-      {
-        "url": "electrumxprux02.sytes.net:50001",
-        "protocol": "TCP"
-      }	  	      
+      }
       ],
       "explorer_url": [
         "https://explorer.prux.info/"


### PR DESCRIPTION
not even in DNS any more: `failed to lookup address information: No address associated with hostname`