### PR TITLE
fix disapearing support icon

### DIFF
--- a/atomic_defi_design/Dex/Sidebar/FigurativeLine.qml
+++ b/atomic_defi_design/Dex/Sidebar/FigurativeLine.qml
@@ -22,8 +22,8 @@ Line
         anchors.fill: _icon
         source: _icon
         color: !_icon.enabled ? Dex.CurrentTheme.textDisabledColor :
-               mouseArea.containsMouse && currentLineType !== type ? Dex.CurrentTheme.sidebarLineTextHovered :
-               currentLineType === type ?                            Dex.CurrentTheme.sidebarLineTextSelected :
-                                                                     Dex.CurrentTheme.foregroundColor
+               mouseArea.containsMouse && currentLineType !== type       ? Dex.CurrentTheme.sidebarLineTextHovered :
+               currentLineType === type && type != Main.LineType.Support ? Dex.CurrentTheme.sidebarLineTextSelected :
+                                                                           Dex.CurrentTheme.foregroundColor
     }
 }

--- a/atomic_defi_design/Dex/Sidebar/Line.qml
+++ b/atomic_defi_design/Dex/Sidebar/Line.qml
@@ -35,10 +35,10 @@ Item
             weight: Font.Normal
         })
         style: Text.Normal
-        color: !enabled ?                                             Dex.CurrentTheme.textDisabledColor :
-               _mouseArea.containsMouse && currentLineType !== type ? Dex.CurrentTheme.sidebarLineTextHovered :
-               currentLineType === type ?                             Dex.CurrentTheme.sidebarLineTextSelected :
-                                                                      Dex.CurrentTheme.foregroundColor
+        color: !enabled                                                  ? Dex.CurrentTheme.textDisabledColor :
+               _mouseArea.containsMouse && currentLineType !== type      ? Dex.CurrentTheme.sidebarLineTextHovered :
+               currentLineType === type && type != Main.LineType.Support ? Dex.CurrentTheme.sidebarLineTextSelected :
+                                                                           Dex.CurrentTheme.foregroundColor
     }
 
     DexMouseArea

--- a/atomic_defi_design/Dex/Support/Support.qml
+++ b/atomic_defi_design/Dex/Support/Support.qml
@@ -11,6 +11,8 @@ import App 1.0
 Item {
     id: root
 
+    readonly property bool update_needed: API.app.self_update_service.update_needed
+
     DexFlickable {
         id: layout_background
 


### PR DESCRIPTION
Currently in lite mode, when you select the Support line in sidebar, the icon and text disappears. This PR makes it not disappear.