### PR TITLE
allow scoop to run as admin

### DIFF
--- a/ci_tools_atomic_dex/ci_scripts/windows_script.ps1
+++ b/ci_tools_atomic_dex/ci_scripts/windows_script.ps1
@@ -6,7 +6,7 @@ iwr -useb 'https://raw.githubusercontent.com/scoopinstaller/install/master/insta
 #Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh') -RunAsAdmin
 scoop install llvm --global
 scoop install ninja --global
-scoop install cmake@3.22.0
+scoop install cmake@3.22.0 --global
 scoop install git --global
 scoop install 7zip  --global
 scoop cache rm 7zip

--- a/ci_tools_atomic_dex/ci_scripts/windows_script.ps1
+++ b/ci_tools_atomic_dex/ci_scripts/windows_script.ps1
@@ -1,6 +1,9 @@
 Set-ExecutionPolicy RemoteSigned -scope CurrentUser
 
-Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh') -RunAsAdmin
+iwr -useb 'https://raw.githubusercontent.com/scoopinstaller/install/master/install.ps1' -outfile 'install.ps1'
+.\install.ps1 -RunAsAdmin
+
+#Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh') -RunAsAdmin
 scoop install llvm --global
 scoop install ninja --global
 scoop install cmake@3.22.0

--- a/ci_tools_atomic_dex/ci_scripts/windows_script.ps1
+++ b/ci_tools_atomic_dex/ci_scripts/windows_script.ps1
@@ -1,11 +1,11 @@
 Set-ExecutionPolicy RemoteSigned -scope CurrentUser
 
-Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
-scoop install llvm --global --RunAsAdmin
-scoop install ninja --global --RunAsAdmin
-scoop install cmake@3.22.0 --global --RunAsAdmin
-scoop install git --global --RunAsAdmin
-scoop install 7zip  --global --RunAsAdmin
+Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh') -RunAsAdmin
+scoop install llvm --global
+scoop install ninja --global
+scoop install cmake@3.22.0
+scoop install git --global
+scoop install 7zip  --global
 scoop cache rm 7zip
 scoop cache rm git
 scoop cache rm cmake

--- a/ci_tools_atomic_dex/ci_scripts/windows_script.ps1
+++ b/ci_tools_atomic_dex/ci_scripts/windows_script.ps1
@@ -1,11 +1,11 @@
 Set-ExecutionPolicy RemoteSigned -scope CurrentUser
 
 Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
-scoop install llvm --global
-scoop install ninja --global
-scoop install cmake@3.22.0 --global
-scoop install git --global
-scoop install 7zip  --global
+scoop install llvm --global --RunAsAdmin
+scoop install ninja --global --RunAsAdmin
+scoop install cmake@3.22.0 --global --RunAsAdmin
+scoop install git --global --RunAsAdmin
+scoop install 7zip  --global --RunAsAdmin
 scoop cache rm 7zip
 scoop cache rm git
 scoop cache rm cmake


### PR DESCRIPTION
To overcome errors like https://github.com/KomodoPlatform/atomicDEX-Desktop/runs/5479003485?check_suite_focus=true

![image](https://user-images.githubusercontent.com/35845239/157437930-efda2e88-66ea-49da-b7c0-8038a1184865.png)
