### PR TITLE
better default value for checkbox labels

### DIFF
--- a/atomic_defi_design/Dex/Components/DexCheckBox.qml
+++ b/atomic_defi_design/Dex/Components/DexCheckBox.qml
@@ -16,7 +16,7 @@ CheckBox
 
     property alias boxWidth: _indicator.implicitWidth
     property alias boxHeight: _indicator.implicitHeight
-    property int labelwidth: 200
+    property int labelWidth: control.width - boxWidth
 
     Universal.accent: Dex.CurrentTheme.accentColor
     Universal.foreground: Dex.CurrentTheme.foregroundColor
@@ -27,7 +27,7 @@ CheckBox
     contentItem: DefaultText
     {
         id: _label
-        width: labelwidth
+        width: labelWidth
         text: control.text
         font: control.font
         color: control.textColor

--- a/atomic_defi_design/Dex/Components/EulaModal.qml
+++ b/atomic_defi_design/Dex/Components/EulaModal.qml
@@ -57,6 +57,7 @@ MultipageModal
         {
             id: accept_eula
             visible: !close_only
+            labelWidth: eula_rect.width - 80
             text: qsTr("Accept EULA")
         }
 
@@ -64,6 +65,7 @@ MultipageModal
         {
             id: accept_tac
             visible: !close_only
+            labelWidth: eula_rect.width - 80
             text: qsTr("Accept Terms and Conditions")
         }
 

--- a/atomic_defi_design/Dex/Exchange/ProView/PlaceOrderForm/OrderForm.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/PlaceOrderForm/OrderForm.qml
@@ -199,6 +199,7 @@ ColumnLayout
 
         boxWidth: 20.76
         boxHeight: 20.76
+        labelWidth: parent.width - 40
         text: qsTr("Use custom minimum trade amount")
         textColor: Dex.CurrentTheme.foregroundColor3
         font.pixelSize: 13

--- a/atomic_defi_design/Dex/Exchange/Trade/ConfirmTradeModal.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/ConfirmTradeModal.qml
@@ -164,7 +164,7 @@ MultipageModal
 
                 spacing: 2
                 text: qsTr("Use custom protection settings for incoming %1 transactions", "TICKER").arg(rel_ticker)
-                labelwidth: 200
+                labelWidth: 200
                 boxWidth: 24
                 boxHeight: 24
                 label.horizontalAlignment: Text.AlignHCenter

--- a/atomic_defi_design/Dex/Portfolio/Portfolio.qml
+++ b/atomic_defi_design/Dex/Portfolio/Portfolio.qml
@@ -246,6 +246,7 @@ Item {
                             text: qsTr("Show only coins with balance") + " <b>%1</b>".arg(qsTr("(%1/%2)").arg(coinsList.count).arg(portfolio_mdl.length))
                             textColor: Dex.CurrentTheme.foregroundColor2
                             label.font.pixelSize: 14
+                            labelWidth: 200
                             checked: portfolio_coins.with_balance
                             onCheckedChanged: portfolio_coins.with_balance = checked
                             Component.onDestruction: portfolio_coins.with_balance = false


### PR DESCRIPTION
I think a bug was introduced by https://github.com/KomodoPlatform/atomicDEX-Desktop/pull/1703 leading to the situation below
![image](https://user-images.githubusercontent.com/35845239/161560815-f11e866a-1ad9-4fd1-a9dd-ee7883aff572.png)

This PR should resolve that issue using a better default value, and includes more explicitly set `labelWidth` values for other place where the `DefaultCheckBox` component is used