### PR TITLE
Fix combo box highlighting and search text

### DIFF
--- a/atomic_defi_design/Dex/Components/ComboBoxWithTitle.qml
+++ b/atomic_defi_design/Dex/Components/ComboBoxWithTitle.qml
@@ -14,7 +14,7 @@ ColumnLayout
 
     TitleText { id: title_text }
 
-    DefaultComboBox
+    DexComboBox
     {
         id: input_field
         Layout.preferredWidth: 300

--- a/atomic_defi_design/Dex/Components/DexComboBox.qml
+++ b/atomic_defi_design/Dex/Components/DexComboBox.qml
@@ -118,6 +118,7 @@ ComboBox
     // Each dropdown item
     delegate: ItemDelegate
     {
+        id: combo_item
         Universal.accent: Dex.CurrentTheme.comboBoxDropdownItemHighlightedColor
         width: control.width
         highlighted: control.highlightedIndex === index
@@ -128,6 +129,11 @@ ComboBox
             font: DexTypo.subtitle2
             text_value: control.dropdownLineText(model)
             elide: Text.ElideRight
+        }
+
+        background: DexRectangle {
+            anchors.fill: combo_item
+            color: combo_item.highlighted ? Dex.CurrentTheme.comboBoxDropdownItemHighlightedColor : "transparent"
         }
     }
 

--- a/atomic_defi_design/Dex/Components/DexListView.qml
+++ b/atomic_defi_design/Dex/Components/DexListView.qml
@@ -8,9 +8,9 @@ ListView
 {
     id: root
 
+    property bool scrollbar_visible: contentItem.childrenRect.height > height
     property alias position: scrollVert.position
     property alias scrollVert: scrollVert
-    property bool scrollbar_visible: contentItem.childrenRect.height > height
     readonly property double scrollbar_margin: scrollbar_visible ? 8 : 0
     property bool visibleBackground: false
 
@@ -32,7 +32,8 @@ ListView
     {
         SmoothedAnimation
         {
-            duration: Style.animationDuration * 0.5;velocity: -1
+            duration: Style.animationDuration * 0.5
+            velocity: -1
         }
     }
 }

--- a/atomic_defi_design/Dex/Components/DexPaginator.qml
+++ b/atomic_defi_design/Dex/Components/DexPaginator.qml
@@ -88,7 +88,7 @@ RowLayout
         onCurrentValueChanged: Constants.API.app.orders_mdl.limit_nb_elements = currentValue
     }
 
-    DefaultText
+    DexText
     {
         Layout.preferredWidth: (root.width / 100) * 16
         Layout.leftMargin: 20

--- a/atomic_defi_design/Dex/Components/DexPaginator.qml
+++ b/atomic_defi_design/Dex/Components/DexPaginator.qml
@@ -70,7 +70,7 @@ RowLayout
         refreshBtn()
     }
 
-    DefaultComboBox
+    DexComboBox
     {
         id: itemsPerPageComboBox
 

--- a/atomic_defi_design/Dex/Components/DexTextField.qml
+++ b/atomic_defi_design/Dex/Components/DexTextField.qml
@@ -54,7 +54,7 @@ TextField
 
     RightClickMenu {}
 
-    DefaultText
+    DexLabel
     {
         id: left_text
         visible: text_value !== ""
@@ -65,7 +65,7 @@ TextField
         font.pixelSize: text_field.font.pixelSize
     }
 
-    DefaultText
+    DexLabel
     {
         id: right_text
         visible: text_value !== ""

--- a/atomic_defi_design/Dex/Components/Pagination.qml
+++ b/atomic_defi_design/Dex/Components/Pagination.qml
@@ -8,6 +8,8 @@ import "../Constants"
 import App 1.0
 import Dex.Themes 1.0 as Dex
 
+// TODO: confirm this component no longer in use; delete.
+
 RowLayout
 {
     id: control

--- a/atomic_defi_design/Dex/Components/SearchField.qml
+++ b/atomic_defi_design/Dex/Components/SearchField.qml
@@ -15,7 +15,7 @@ Rectangle
     color: Dex.CurrentTheme.accentColor
     radius: 18
 
-    DefaultImage
+    DexImage
     {
         id: _searchIcon
         anchors.left: parent.left
@@ -27,7 +27,7 @@ Rectangle
 
         source: General.image_path + "exchange-search.svg"
 
-        DefaultColorOverlay
+        DexColorOverlay
         {
             anchors.fill: parent
             source: parent
@@ -35,13 +35,12 @@ Rectangle
         }
     }
 
-    TextField
+    DexTextField
     {
         id: _textField
 
         anchors.left: _searchIcon.right
-        anchors.verticalCenter: _searchIcon.verticalCenter
-        anchors.verticalCenterOffset: 1
+        anchors.verticalCenter: parent.verticalCenter
         width: parent.width - x - 5
         height: parent.height
 

--- a/atomic_defi_design/Dex/Exchange/ProView/DexComboBoxLine.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/DexComboBoxLine.qml
@@ -18,10 +18,6 @@ RowLayout
     property alias bottom_text: bottom_line.text_value
 
     Behavior on color { ColorAnimation { duration: Style.animationDuration } }
-    visible: {
-        console.log("Highlighting " + details.ticker)
-        true
-    }
 
     DexImage
     {
@@ -69,11 +65,5 @@ RowLayout
                 Component.onCompleted: font.pixelSize = 11.5
             }
         }
-    }
-
-    DexMouseArea
-    {
-        id: combo_line
-        anchors.fill: parent
     }
 }

--- a/atomic_defi_design/Dex/Exchange/ProView/DexComboBoxLine.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/DexComboBoxLine.qml
@@ -18,8 +18,12 @@ RowLayout
     property alias bottom_text: bottom_line.text_value
 
     Behavior on color { ColorAnimation { duration: Style.animationDuration } }
+    visible: {
+        console.log("Highlighting " + details.ticker)
+        true
+    }
 
-    DefaultImage
+    DexImage
     {
         id: icon
         source: General.coinIcon(ticker)
@@ -37,7 +41,7 @@ RowLayout
             anchors.verticalCenter: parent.verticalCenter
             width: root.width - 40
 
-            DefaultText
+            DexText
             {
                 Layout.preferredWidth: parent.width - 15
 
@@ -48,7 +52,7 @@ RowLayout
                 wrapMode: Text.NoWrap
             }
 
-            DefaultText
+            DexText
             {
                 id: bottom_line
 
@@ -65,5 +69,11 @@ RowLayout
                 Component.onCompleted: font.pixelSize = 11.5
             }
         }
+    }
+
+    DexMouseArea
+    {
+        id: combo_line
+        anchors.fill: parent
     }
 }

--- a/atomic_defi_design/Dex/Exchange/ProView/SweetDexComboBox.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/SweetDexComboBox.qml
@@ -57,16 +57,16 @@ ComboBox
 
     height: 80
 
-    background: DefaultRectangle
+    background: DexRectangle
     {
-        color: Dex.CurrentTheme.floatingBackgroundColor
+        color: mouse_area.containsMouse ? Dex.CurrentTheme.accentColor : Dex.CurrentTheme.floatingBackgroundColor
         radius: 10
     }
 
     // Each dropdown item
     delegate: ItemDelegate
     {
-        Universal.accent: control.lineHoverColor
+        Universal.accent: Dex.hoverColor
         width: control.width
         highlighted: control.highlightedIndex === index
         contentItem: DexComboBoxLine { details: model }
@@ -78,7 +78,7 @@ ComboBox
     {
         id: popup
 
-        readonly property double max_height: 450//control.Window.height - bottomMargin - mapToItem(control.Window.contentItem, x, y).y
+        readonly property double max_height: 450 //control.Window.height - bottomMargin - mapToItem(control.Window.contentItem, x, y).y
 
         width: control.width
         height: Math.min(contentItem.implicitHeight, popup.max_height)
@@ -93,12 +93,12 @@ ComboBox
             anchors.rightMargin: 5
 
             // Search input
-            DefaultTextField
+            DexTextField
             {
                 id: input_coin_filter
                 background: Item
                 {
-                    DefaultRectangle
+                    DexRectangle
                     {
                         anchors.fill: parent
                         anchors.rightMargin: 2
@@ -150,12 +150,14 @@ ComboBox
                     function onClosed() { input_coin_filter.reset() }
                 }
             }
+
             Item
             {
                 Layout.maximumHeight: popup.max_height - 100
                 Layout.fillWidth: true
                 implicitHeight: popup_list_view.contentHeight + 5
-                DefaultListView
+
+                DexListView
                 {
                     id: popup_list_view
                      // Scrollbar appears if this extra space is not added
@@ -164,7 +166,7 @@ ComboBox
                     anchors.fill: parent
                     anchors.rightMargin: 2
 
-                    DefaultMouseArea
+                    DexMouseArea
                     {
                         anchors.fill: parent
                         acceptedButtons: Qt.NoButton
@@ -173,7 +175,7 @@ ComboBox
             }
         }
 
-        background: DefaultRectangle
+        background: DexRectangle
         {
             width: parent.width
             y: -5

--- a/atomic_defi_design/Dex/Exchange/ProView/SweetDexComboBox.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/SweetDexComboBox.qml
@@ -72,6 +72,7 @@ ComboBox
         highlighted: control.highlightedIndex === index
         contentItem: DexComboBoxLine { details: model }
         z: 5
+
         background: DexRectangle {
             anchors.fill: combo_item
             color: combo_item.highlighted ? Dex.CurrentTheme.comboBoxDropdownItemHighlightedColor : "transparent"

--- a/atomic_defi_design/Dex/Exchange/ProView/SweetDexComboBox.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/SweetDexComboBox.qml
@@ -59,18 +59,23 @@ ComboBox
 
     background: DexRectangle
     {
-        color: mouse_area.containsMouse ? Dex.CurrentTheme.accentColor : Dex.CurrentTheme.floatingBackgroundColor
+        color: Dex.CurrentTheme.floatingBackgroundColor
         radius: 10
     }
 
     // Each dropdown item
     delegate: ItemDelegate
     {
-        Universal.accent: Dex.hoverColor
+        id: combo_item
+        Universal.accent: control.lineHoverColor
         width: control.width
         highlighted: control.highlightedIndex === index
         contentItem: DexComboBoxLine { details: model }
         z: 5
+        background: DexRectangle {
+            anchors.fill: combo_item
+            color: combo_item.highlighted ? Dex.CurrentTheme.comboBoxDropdownItemHighlightedColor : "transparent"
+        }
     }
 
     // Dropdown itself
@@ -150,13 +155,11 @@ ComboBox
                     function onClosed() { input_coin_filter.reset() }
                 }
             }
-
             Item
             {
                 Layout.maximumHeight: popup.max_height - 100
                 Layout.fillWidth: true
                 implicitHeight: popup_list_view.contentHeight + 5
-
                 DexListView
                 {
                     id: popup_list_view
@@ -165,7 +168,6 @@ ComboBox
                     currentIndex: control.highlightedIndex
                     anchors.fill: parent
                     anchors.rightMargin: 2
-
                     DexMouseArea
                     {
                         anchors.fill: parent

--- a/atomic_defi_design/Dex/Settings/Combo_fiat.qml
+++ b/atomic_defi_design/Dex/Settings/Combo_fiat.qml
@@ -15,7 +15,8 @@ import "../Constants"
 import App 1.0
 
 
-ComboBoxWithTitle {
+ComboBoxWithTitle
+{
     id: combo_fiat
     title: qsTr("Fiat")
     width: parent.width-30
@@ -24,30 +25,37 @@ ComboBoxWithTitle {
     model: fiats
 
     property bool initialized: false
-    onCurrentIndexChanged: {
-        if(initialized) {
+    onCurrentIndexChanged:
+    {
+        if(initialized)
+        {
             const new_fiat = fiats[currentIndex]
             API.app.settings_pg.current_fiat = new_fiat
             API.app.settings_pg.current_currency = new_fiat
         }
     }
-    Component.onCompleted: {
+
+    Component.onCompleted:
+    {
         currentIndex = model.indexOf(API.app.settings_pg.current_fiat)
         initialized = true
     }
 
-    RowLayout {
+    RowLayout
+    {
         Layout.topMargin: 5
         Layout.fillWidth: true
         Layout.leftMargin: 2
         Layout.rightMargin: Layout.leftMargin
 
-        DefaultText {
+        DexText
+        {
             text: qsTr("Recommended: ")
             font.pixelSize: Style.textSizeSmall4
         }
 
-        Grid {
+        Grid
+        {
             Layout.leftMargin: 30
             Layout.alignment: Qt.AlignVCenter
 
@@ -58,19 +66,24 @@ ComboBoxWithTitle {
 
             layoutDirection: Qt.LeftToRight
 
-            Repeater {
+            Repeater
+            {
                 model: recommended_fiats
 
-                delegate: DefaultText {
+                delegate: DexText
+                {
                     text: modelData
                     color: DexTheme.foregroundColor
                     opacity: fiats_mouse_area.containsMouse ? .7 : 1
 
-                    DefaultMouseArea {
+                    DexMouseArea
+                    {
                         id: fiats_mouse_area
                         anchors.fill: parent
                         hoverEnabled: true
-                        onClicked: {
+
+                        onClicked:
+                        {
                             API.app.settings_pg.current_fiat = modelData
                             API.app.settings_pg.current_currency = modelData
                             combo_fiat.currentIndex = combo_fiat.model.indexOf(API.app.settings_pg.current_fiat)

--- a/atomic_defi_design/Dex/Settings/Languages.qml
+++ b/atomic_defi_design/Dex/Settings/Languages.qml
@@ -7,13 +7,17 @@ import "../Components"
 import "../Constants"
 import App 1.0
 
-ColumnLayout {
+ColumnLayout
+{
     property alias show_label: label.visible
 
-    RowLayout {
+    RowLayout
+    {
         Layout.alignment: Qt.AlignVCenter
         spacing: 5
-        DexLabel {
+
+        DexLabel
+        {
             id: label
             visible: false
             Layout.alignment: Qt.AlignVCenter
@@ -21,7 +25,8 @@ ColumnLayout {
             text_value: qsTr("Language") + ":"
         }
 
-        Grid {
+        Grid
+        {
             Layout.alignment: Qt.AlignVCenter
             Layout.fillWidth: true
 
@@ -30,28 +35,36 @@ ColumnLayout {
             columns: 8
             spacing: 10
 
-            Repeater {
+            Repeater
+            {
                 model: API.app.settings_pg.get_available_langs()
-                delegate: ClipRRect {
+
+                delegate: ClipRRect
+                {
                     width: 30 // Current icons have too much space around them
                     height: 30
                     radius: 15
                     //color: API.app.settings_pg.lang === model.modelData ? Style.colorTheme11 : mouse_area.containsMouse ? Style.colorTheme4 : Style.applyOpacity(Style.colorTheme4)
 
-                    DefaultImage {
+                    DexImage
+                    {
                         id: image
                         anchors.centerIn: parent
                         source: General.image_path + "lang/" + model.modelData + ".png"
                         width: 40
                         height: 40
                         opacity: model.modelData === API.app.settings_pg.lang ? 1 : mouse_area.containsMouse ? 0.85 : 0.7
+
                         // Click area
-                        DefaultMouseArea {
+                        DexMouseArea
+                        {
                             id: mouse_area
                             anchors.fill: parent
                             acceptedButtons: Qt.LeftButton | Qt.RightButton
                             hoverEnabled: true
-                            onClicked: {
+
+                            onClicked:
+                            {
                                 API.app.settings_pg.lang = model.modelData;
                                 console.info("Switched language to %1".arg(API.app.settings_pg.lang));
                             }

--- a/atomic_defi_design/Dex/Settings/SettingModal.qml
+++ b/atomic_defi_design/Dex/Settings/SettingModal.qml
@@ -225,7 +225,7 @@ Qaterial.Dialog
                                     font: DexTypo.subtitle1
                                     text: qsTr("Enable Desktop Notifications")
                                 }
-                                DefaultSwitch
+                                DexSwitch
                                 {
                                     Layout.alignment: Qt.AlignVCenter
                                     Component.onCompleted: checked = API.app.settings_pg.notification_enabled
@@ -244,7 +244,7 @@ Qaterial.Dialog
                                     font: DexTypo.subtitle1
                                     text: qsTr("Maximum number of enabled coins")
                                 }
-                                DefaultComboBox
+                                DexComboBox
                                 {
                                     id: enableable_coins_count_combo_box
                                     Layout.preferredWidth: 62


### PR DESCRIPTION
closes https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1736

Combo box fix applied to:
- pro view coin selectors
- settings > fiat
- settings > language
- settings > max coins
- settings > theme / font
- order history pagination (items per page)

Search bar fix applied to:
- enable coin search
- asset search (wallet page)
- asset search (portfolio page)
- From coin search (simple view)
- To coin search (simple view)
- wallet search (at login)

+ misc code style updates & migrating to `dex` prefixed components.