### PR TITLE
better combobox height

### DIFF
--- a/atomic_defi_design/Dex/Exchange/ProView/SearchableTickerSelector.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/SearchableTickerSelector.qml
@@ -18,14 +18,15 @@ Dex.ComboBoxWithSearchBar
     property string ticker
     property bool index_changed: false
     
-    height: 80
+    height: 60
     enabled: !block_everything
-
-    popupMaxHeight: 500
 
     model: control.ticker_list
     textRole: "ticker"
     valueRole: "ticker"
+
+    popupMaxHeight: Math.min(model.rowCount() * 70 + 70, 600)
+    popupForceMaxHeight: true
 
     searchBar.visible: true
     searchBar.searchModel: control.ticker_list


### PR DESCRIPTION
test: pro view combo box expands with more coins enabled, but does not overflow app or return "polish loop" or "binding loop" errors in logs.