### PR TITLE
increase opacity for disabled coin icons

### DIFF
--- a/atomic_defi_design/Dex/Exchange/Trade/SimpleView/SubBestOrder.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/SimpleView/SubBestOrder.qml
@@ -168,7 +168,7 @@ DexListView
                     Layout.preferredWidth: parent._iconWidth
                     Layout.preferredHeight: 24
                     source: General.coinIcon(coin)
-                    opacity: !_isCoinEnabled? .1 : 1
+                    opacity: !_isCoinEnabled? .3 : 1
                 }
 
                 DexLabel                          // Order Token Name


### PR DESCRIPTION
resolves final item (5)  and closes https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1485

before:
![image](https://user-images.githubusercontent.com/35845239/177182973-0d48c3f1-8fd4-4813-9c3d-df3d18360ff3.png)
![image](https://user-images.githubusercontent.com/35845239/177183029-5019b508-8b89-4185-b9e9-ce5ddc0b62ff.png)


after:
![image](https://user-images.githubusercontent.com/35845239/177182460-b50b19c8-4103-4686-8cc7-506621e27e6c.png)
![image](https://user-images.githubusercontent.com/35845239/177182652-a50491a5-c3fb-46ff-80ab-38d710118357.png)
