### PR TITLE
hide explorer link if fresh wallet

### DIFF
--- a/atomic_defi_design/Dex/Wallet/Main.qml
+++ b/atomic_defi_design/Dex/Wallet/Main.qml
@@ -932,9 +932,9 @@ Item
                         visible:
                         {
                             if (addressURL) console.log("addressURL: " + addressURL)
-                            return !api_wallet_page.tx_fetching_failed && !api_wallet_page.tx_fetching_busy && addressURL != ""
+                            return api_wallet_page.tx_fetching_busy ? false : addressURL == "" ? false : api_wallet_page.tx_fetching_failed 
                         }
-                        text_value:  qsTr("Click to view your address on %1 block explorer").arg(api_wallet_page.ticker)
+                        text_value:  qsTr("Click to view your address on %1 (%2) block explorer").arg(current_ticker_infos.name).arg(api_wallet_page.ticker)
                         font.pixelSize: Style.textSize
                         color: explorer_mouseArea.containsMouse ? Dex.CurrentTheme.textSelectionColor : Dex.CurrentTheme.foregroundColor
 

--- a/atomic_defi_design/Dex/Wallet/Main.qml
+++ b/atomic_defi_design/Dex/Wallet/Main.qml
@@ -736,7 +736,8 @@ Item
 
             radius: 18
 
-            onTickerChanged: loadChart()
+            // Chart disabled
+            // onTickerChanged: loadChart()
 
             function loadChart()
             {
@@ -790,28 +791,28 @@ Item
 
                 console.debug("Wallet: Loading chart for %1".arg(symbol))
 
-//                webEngineView.loadHtml(`<style>
-//                                        body { margin: 0; background: %1 }
-//                                        </style>
-//                                        <!-- TradingView Widget BEGIN -->
-//                                        <div class="tradingview-widget-container">
-//                                          <div class="tradingview-widget-container__widget"></div>
-//                                          <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-mini-symbol-overview.js" async>
-//                                          {
-//                                              "symbol": "${symbol}",
-//                                              "width": "100%",
-//                                              "height": "100%",
-//                                              "locale": "en",
-//                                              "dateRange": "1D",
-//                                              "colorTheme": "dark",
-//                                              "trendLineColor": "%2",
-//                                              "isTransparent": true,
-//                                              "autosize": false,
-//                                              "largeChartUrl": ""
-//                                          }
-//                                          </script>
-//                                        </div>
-//                                        <!-- TradingView Widget END -->`.arg(Dex.CurrentTheme.floatingBackgroundColor).arg(Dex.CurrentTheme.textSelectionColor))
+                webEngineView.loadHtml(`<style>
+                                        body { margin: 0; background: %1 }
+                                        </style>
+                                        <!-- TradingView Widget BEGIN -->
+                                        <div class="tradingview-widget-container">
+                                          <div class="tradingview-widget-container__widget"></div>
+                                          <script type="text/javascript" src="https://s3.tradingview.com/external-embedding/embed-widget-mini-symbol-overview.js" async>
+                                          {
+                                              "symbol": "${symbol}",
+                                              "width": "100%",
+                                              "height": "100%",
+                                              "locale": "en",
+                                              "dateRange": "1D",
+                                              "colorTheme": "dark",
+                                              "trendLineColor": "%2",
+                                              "isTransparent": true,
+                                              "autosize": false,
+                                              "largeChartUrl": ""
+                                          }
+                                          </script>
+                                        </div>
+                                        <!-- TradingView Widget END -->`.arg(Dex.CurrentTheme.floatingBackgroundColor).arg(Dex.CurrentTheme.textSelectionColor))
             }
 
             WebEngineView
@@ -826,7 +827,8 @@ Item
                 target: Dex.CurrentTheme
                 function onThemeChanged()
                 {
-                    loadChart();
+                    // Chart disabled
+                    // loadChart();
                 }
             }
 
@@ -927,7 +929,11 @@ Item
                         id: explorerLink
                         Layout.topMargin: 24
                         Layout.alignment: Qt.AlignHCenter
-                        visible: !api_wallet_page.tx_fetching_busy && addressURL != ""
+                        visible:
+                        {
+                            if (addressURL) console.log("addressURL: " + addressURL)
+                            return !api_wallet_page.tx_fetching_failed && !api_wallet_page.tx_fetching_busy && addressURL != ""
+                        }
                         text_value:  qsTr("Click to view your address on %1 block explorer").arg(api_wallet_page.ticker)
                         font.pixelSize: Style.textSize
                         color: explorer_mouseArea.containsMouse ? Dex.CurrentTheme.textSelectionColor : Dex.CurrentTheme.foregroundColor
@@ -944,7 +950,6 @@ Item
                             }
                         }
                     }
-
 
                     Item { Layout.fillHeight: true }
                 }

--- a/src/core/atomicdex/pages/qt.wallet.page.cpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.cpp
@@ -114,7 +114,6 @@ namespace atomic_dex
         {
             SPDLOG_INFO("new ticker: {}", ticker.toStdString());
             this->set_tx_fetching_busy(true);
-            SPDLOG_INFO("set_tx_fetching_busy to true");
             m_transactions_mdl->reset();
             mm2_system.fetch_infos_thread(true, true);
             emit currentTickerChanged();

--- a/src/core/atomicdex/pages/qt.wallet.page.cpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.cpp
@@ -114,6 +114,7 @@ namespace atomic_dex
         {
             SPDLOG_INFO("new ticker: {}", ticker.toStdString());
             this->set_tx_fetching_busy(true);
+            SPDLOG_INFO("set_tx_fetching_busy to true");
             m_transactions_mdl->reset();
             mm2_system.fetch_infos_thread(true, true);
             emit currentTickerChanged();
@@ -233,6 +234,24 @@ namespace atomic_dex
             emit txFetchingStatusChanged();
         }
     }
+
+    bool
+    atomic_dex::wallet_page::is_tx_fetching_failed() const
+    {
+        return m_tx_fetching_failed;
+    }
+
+    void
+    atomic_dex::wallet_page::set_tx_fetching_failed(bool status)
+    {
+        if (m_tx_fetching_failed != status)
+        {
+            m_tx_fetching_failed = status;
+            emit txFetchingOutcomeChanged();
+        }
+    }
+
+
 
     QVariant
     wallet_page::get_ticker_infos() const
@@ -790,6 +809,14 @@ namespace atomic_dex
                 //! Update tx (only unconfirmed) or insert (new tx)
                 // SPDLOG_DEBUG("updating / insert tx");
                 m_transactions_mdl->update_or_insert_transactions(transactions);
+            }
+            if (ec)
+            {
+                this->set_tx_fetching_failed(true);
+            }
+            else
+            {
+                this->set_tx_fetching_failed(false);
             }
         }
         else

--- a/src/core/atomicdex/pages/qt.wallet.page.hpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.hpp
@@ -48,6 +48,8 @@ namespace atomic_dex
         void                              set_rpc_broadcast_data(QString rpc_data);
         [[nodiscard]] QVariant            get_rpc_send_data() const;
         void                              set_rpc_send_data(QVariant rpc_data);
+        [[nodiscard]] bool                is_tx_fetching_failed() const;
+        void                              set_tx_fetching_failed(bool status);
         [[nodiscard]] bool                is_tx_fetching_busy() const;
         void                              set_tx_fetching_busy(bool status);
         [[nodiscard]] bool                is_convert_address_busy() const;
@@ -99,6 +101,7 @@ namespace atomic_dex
         Q_PROPERTY(bool is_send_busy READ is_send_busy WRITE set_send_busy NOTIFY sendStatusChanged)
         Q_PROPERTY(QVariant send_rpc_data READ get_rpc_send_data WRITE set_rpc_send_data NOTIFY sendDataChanged)
         Q_PROPERTY(bool tx_fetching_busy READ is_tx_fetching_busy WRITE set_tx_fetching_busy NOTIFY txFetchingStatusChanged)
+        Q_PROPERTY(bool tx_fetching_failed READ is_tx_fetching_failed WRITE set_tx_fetching_failed NOTIFY txFetchingOutcomeChanged)
         Q_PROPERTY(bool auth_succeeded READ has_auth_succeeded NOTIFY auth_succeededChanged)
         Q_PROPERTY(bool send_available READ is_send_available NOTIFY sendAvailableChanged)
         Q_PROPERTY(QString send_availability_state READ get_send_availability_state NOTIFY sendAvailabilityStateChanged)
@@ -123,6 +126,7 @@ namespace atomic_dex
         void sendDataChanged();
         void transactionsMdlChanged();
         void txFetchingStatusChanged();
+        void txFetchingOutcomeChanged();
         void auth_succeededChanged();
         void sendAvailabilityStateChanged();
         void sendAvailableChanged();
@@ -141,6 +145,7 @@ namespace atomic_dex
         std::atomic_bool                               m_is_broadcast_busy{false};
         std::atomic_bool                               m_is_send_busy{false};
         std::atomic_bool                               m_tx_fetching_busy{false};
+        std::atomic_bool                               m_tx_fetching_failed{false};
         std::atomic_bool                               m_validate_address_busy{false};
         std::atomic_bool                               m_convert_address_busy{false};
 


### PR DESCRIPTION
Closes: https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1867

To Test:
- You should see a link for AVAX and AVX20 tokens, as we can't get history or them yet.
- For general utxo coins, for wallet where you have no balance or transactions, you will not see a link.