### PR TITLE
avoid 2 line crypto amount

### DIFF
--- a/atomic_defi_design/Dex/Wallet/Transactions.qml
+++ b/atomic_defi_design/Dex/Wallet/Transactions.qml
@@ -85,7 +85,13 @@ DefaultListView
                 id: crypto_amount
                 Layout.preferredWidth: _cryptoColumnWidth
                 horizontalAlignment: Text.AlignRight
-                text_value: General.formatCrypto(!am_i_sender, amount, api_wallet_page.ticker, false, false, 6, true)
+                text_value:
+                {
+                    api_wallet_page.ticker.length > 6 
+                    ? General.formatCrypto(!am_i_sender, amount, '', false, false, 6, true)
+                    : General.formatCrypto(!am_i_sender, amount, api_wallet_page.ticker, false, false, 6, true)
+
+                }
                 font.pixelSize: description.font.pixelSize
                 color: am_i_sender ? Dex.CurrentTheme.noColor : Dex.CurrentTheme.okColor
                 privacy: true


### PR DESCRIPTION
closes: https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1844

Where a ticker is too long to show without using 2 lines, only the numeric value will be shown.