### PR TITLE
update virustotal action version

### DIFF
--- a/.github/workflows/atomicdex-desktop-release-vt.yml
+++ b/.github/workflows/atomicdex-desktop-release-vt.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       -
         name: VirusTotal Scan
-        uses: crazy-max/ghaction-virustotal@v2.4.1
+        uses: crazy-max/ghaction-virustotal@v3.1.0
         with:
           vt_api_key: ${{ secrets.VT_API_KEY }}
           github_token: ${{ github.token }}


### PR DESCRIPTION
possible fix for https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1899
Change log says it now has large file support
ref: https://github.com/crazy-max/ghaction-virustotal/releases/tag/v3.1.0