### PR TITLE
Smartdex theme

### DIFF
--- a/assets/themes/Default - Dark/colors.json
+++ b/assets/themes/Default - Dark/colors.json
@@ -3,9 +3,9 @@
     "foregroundColor": "#ffffffFF",
     "foregroundColor2": "#7A8EA1FF",
     "foregroundColor3": "#ABC0D3FF",
-    "backgroundColor": "#15182a",
+    "backgroundColor": "#15182AFF",
     "secondBackgroundColor": "#24273DFF",
-    "backgroundColorDeep": "#171a2c",
+    "backgroundColorDeep": "#171A2CFF",
 
     "busyIndicatorColor": "#4986EAFF",
 
@@ -69,7 +69,7 @@
     "textFieldSuffixColor": "#456078FF",
 
     "chartTradingLineBackgroundColor": "#24283dFF",
-    "chartTradingLineColor": "#74fbeeFF",
+    "chartTradingLineColor": "#74FBEEFFFF",
 
     "innerBackgroundColor": "#1F263FFF",
 
@@ -83,7 +83,7 @@
     "userIconColorStart": "#5A68E6FF",
     "userIconColorEnd": "#4986EAAD",
 
-    "sidebarBgColor": "#202337FF",
+    "sidebarBgColor": "#15182AFF",
     "sidebarVersionTextColor": "#2F5688FF",
     "sidebarCursorStartColor": "#31B1F0FF",
     "sidebarCursorEndColor": "#5B69E600",
@@ -98,8 +98,8 @@
 
     "addressBookTagColors": ["#627EEAFF", "#FFD87AFF", "#F7931AFF"],
     
-    "okColor": "#74fbee",
-    "noColor": "#d13990",
+    "okColor": "#74FBEEFF",
+    "noColor": "#D13990FF",
 
     "senderColorStart": "#F85757FF",
     "receiverColorStart": "#845FEFFF",

--- a/assets/themes/Default - Dark/colors.json
+++ b/assets/themes/Default - Dark/colors.json
@@ -1,6 +1,6 @@
 {
     "accentColor": "#2C3D66FF",
-    "foregroundColor": "#ffffffFF",
+    "foregroundColor": "#FFFFFFFF",
     "foregroundColor2": "#7A8EA1FF",
     "foregroundColor3": "#ABC0D3FF",
     "backgroundColor": "#15182AFF",
@@ -14,9 +14,9 @@
     "buttonColorHovered": "#4068B929",
     "buttonColorPressed": "#2932546C",
     "buttonTextDisabledColor": "#444444FF",
-    "buttonTextEnabledColor": "#ffffffFF",
-    "buttonTextHoveredColor": "#ffffffFF",
-    "buttonTextPressedColor": "#ffffffFF",
+    "buttonTextEnabledColor": "#FFFFFFFF",
+    "buttonTextHoveredColor": "#FFFFFFFF",
+    "buttonTextPressedColor": "#FFFFFFFF",
 
     "gradientButtonStartColor": "#4986EAAD",
     "gradientButtonEndColor": "#5A68E6FF",
@@ -69,7 +69,7 @@
     "textFieldSuffixColor": "#456078FF",
 
     "chartTradingLineBackgroundColor": "#24283dFF",
-    "chartTradingLineColor": "#74FBEEFFFF",
+    "chartTradingLineColor": "#74FBEEFF",
 
     "innerBackgroundColor": "#1F263FFF",
 

--- a/assets/themes/Default - Light/colors.json
+++ b/assets/themes/Default - Light/colors.json
@@ -98,8 +98,8 @@
     "okColor": "#00C058FF",
     "noColor": "#E52167FF",
 
-    "senderColorStart": "#F85757",
-    "receiverColorStart": "#845FEF",
+    "senderColorStart": "#F85757FF",
+    "receiverColorStart": "#845FEFFF",
 
     "arrowUpColor": "#F85757FF",
     "arrowDownColor": "#845FEFFF",


### PR DESCRIPTION
Fixes log errors:
```
[17:07:06] [warning] [main.prerequisites.hpp:92] [4039028]: Dex.Graphics.Color.argbStrFromRgbaStr: #171a2c is not an RGBA color
[17:07:06] [warning] [main.prerequisites.hpp:92] [4039028]: Dex.Graphics.Color.argbStrFromRgbaStr: #74fbee is not an RGBA color
[17:07:06] [warning] [main.prerequisites.hpp:92] [4039028]: Dex.Graphics.Color.argbStrFromRgbaStr: #d13990 is not an RGBA color
```

Also fixes sidebar color in dark mode to avoid the to left wierdness.
<-- Before | After -->
![image](https://user-images.githubusercontent.com/35845239/183047735-f9f403d4-9290-4be8-b828-19bd28518dd6.png)

