### PR TITLE
Use regular libtool

### DIFF
--- a/.github/workflows/atomicdex-desktop-ci.yml
+++ b/.github/workflows/atomicdex-desktop-ci.yml
@@ -40,7 +40,7 @@ jobs:
             type: 'release'
 
           - name: osx-qt-5-15-2
-            os: macos-latest
+            os: macos-12
             qt: '5.15.2'
             type: 'release'
 

--- a/ci_tools_atomic_dex/ci_scripts/osx_script.sh
+++ b/ci_tools_atomic_dex/ci_scripts/osx_script.sh
@@ -5,11 +5,12 @@ brew update
 brew tap-new $USER/local-nim
 brew extract --version=1.4.8 nim $USER/local-nim
 
-brew unlink libtool
-wget https://raw.githubusercontent.com/Homebrew/homebrew-core/0fbd6e24c4122e18ade1ec6c5916cb21de14f352/Formula/libtool.rb
-brew install libtool.rb
+# brew unlink libtool
+# wget https://raw.githubusercontent.com/Homebrew/homebrew-core/0fbd6e24c4122e18ade1ec6c5916cb21de14f352/Formula/libtool.rb
+# brew install libtool.rb
 
 brew install autoconf \
+            libtool \
             automake \
             pkgconfig \
             wget \


### PR DESCRIPTION
A while ago, there was an issue with CI due to a conflicting libtool update on the GH actions runners. 
This might now be resolved, so I'm testing removal of the workaround to see if it might resolve https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1902