### PR TITLE
UTXO merging

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,6 +117,7 @@ add_executable(${PROJECT_NAME}_tests MACOSX_BUNDLE ${ICON}
         tests/api/komodo_prices/komodo.prices.tests.cpp
         tests/api/mm2/mm2.rpc.trade.preimage.tests.cpp
         tests/api/mm2/mm2.fraction.tests.cpp
+        tests/api/mm2/mm2.api.utxo.merge.params.tests.cpp
 
         ##! Utilities
         tests/utilities/qt.utilities.tests.cpp

--- a/src/core/atomicdex/api/mm2/rpc.electrum.cpp
+++ b/src/core/atomicdex/api/mm2/rpc.electrum.cpp
@@ -35,10 +35,12 @@ namespace mm2::api
             j["swap_contract_address"] = cfg.is_testnet ? cfg.testnet_qrc_swap_contract_address : cfg.mainnet_qrc_swap_contract_address;
             j["fallback_swap_contract"] = cfg.is_testnet ? cfg.testnet_fallback_qrc_swap_contract_address : cfg.mainnet_fallback_qrc_swap_contract_address;
         }
-        if (cfg.address_format.has_value()) {
+        if (cfg.address_format.has_value())
+        {
             j["address_format"] = cfg.address_format.value();
         }
-        if (cfg.merge_params.has_value()) {
+        if (cfg.merge_params.has_value())
+        {
             j["utxo_merge_params"] = cfg.merge_params.value();
         }
     }

--- a/src/core/atomicdex/api/mm2/rpc.electrum.cpp
+++ b/src/core/atomicdex/api/mm2/rpc.electrum.cpp
@@ -41,7 +41,6 @@ namespace mm2::api
         if (cfg.merge_params.has_value()) {
             j["utxo_merge_params"] = cfg.merge_params.value();
         }
-        SPDLOG_INFO("electrum: {}", j.dump());
     }
 
     //! Deserialization

--- a/src/core/atomicdex/api/mm2/rpc.electrum.cpp
+++ b/src/core/atomicdex/api/mm2/rpc.electrum.cpp
@@ -38,7 +38,10 @@ namespace mm2::api
         if (cfg.address_format.has_value()) {
             j["address_format"] = cfg.address_format.value();
         }
-        //SPDLOG_INFO("electrum: {}", j.dump());
+        if (cfg.merge_params.has_value()) {
+            j["utxo_merge_params"] = cfg.merge_params.value();
+        }
+        SPDLOG_INFO("electrum: {}", j.dump());
     }
 
     //! Deserialization

--- a/src/core/atomicdex/api/mm2/rpc.electrum.hpp
+++ b/src/core/atomicdex/api/mm2/rpc.electrum.hpp
@@ -27,16 +27,17 @@ namespace mm2::api
 {
     struct electrum_request
     {
-        std::string                              coin_name;
-        std::vector<atomic_dex::electrum_server> servers;
-        CoinType                                 coin_type;
-        bool                                     is_testnet{false};
-        bool                                     with_tx_history{true};
-        const std::string                        testnet_qrc_swap_contract_address{"0xba8b71f3544b93e2f681f996da519a98ace0107a"};
-        const std::string                        testnet_fallback_qrc_swap_contract_address{testnet_qrc_swap_contract_address};
-        const std::string                        mainnet_qrc_swap_contract_address{"0x2f754733acd6d753731c00fee32cb484551cc15d"};
-        const std::string                        mainnet_fallback_qrc_swap_contract_address{mainnet_qrc_swap_contract_address};
-        std::optional<nlohmann::json>            address_format;
+        std::string                                  coin_name;
+        std::vector<atomic_dex::electrum_server>     servers;
+        CoinType                                     coin_type;
+        bool                                         is_testnet{false};
+        bool                                         with_tx_history{true};
+        const std::string                            testnet_qrc_swap_contract_address{"0xba8b71f3544b93e2f681f996da519a98ace0107a"};
+        const std::string                            testnet_fallback_qrc_swap_contract_address{testnet_qrc_swap_contract_address};
+        const std::string                            mainnet_qrc_swap_contract_address{"0x2f754733acd6d753731c00fee32cb484551cc15d"};
+        const std::string                            mainnet_fallback_qrc_swap_contract_address{mainnet_qrc_swap_contract_address};
+        std::optional<nlohmann::json>                address_format;
+        std::optional<nlohmann::json>                merge_params;
     };
 
     struct electrum_answer

--- a/src/core/atomicdex/api/mm2/utxo.merge.params.cpp
+++ b/src/core/atomicdex/api/mm2/utxo.merge.params.cpp
@@ -1,0 +1,32 @@
+/******************************************************************************
+ * Copyright © 2013-2022 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+//! Dependencies Headers
+#include <nlohmann/json.hpp>
+
+//! Project Headers
+#include "utxo.merge.params.hpp"
+
+namespace mm2::api
+{
+    void
+    to_json(nlohmann::json& j, const utxo_merge_params& cfg)
+    {
+        j["merge_at"] = cfg.merge_at;
+        j["check_every"] = cfg.check_every;
+        j["max_merge_at_once"] = cfg.max_merge_at_once;
+    }
+} // namespace mm2::api

--- a/src/core/atomicdex/api/mm2/utxo.merge.params.hpp
+++ b/src/core/atomicdex/api/mm2/utxo.merge.params.hpp
@@ -29,3 +29,8 @@ namespace mm2::api
 
     void to_json(nlohmann::json& j, const utxo_merge_params& cfg);
 }
+
+namespace atomic_dex
+{
+    using t_utxo_merge_params = ::mm2::api::utxo_merge_params;
+} // namespace atomic_dex

--- a/src/core/atomicdex/api/mm2/utxo.merge.params.hpp
+++ b/src/core/atomicdex/api/mm2/utxo.merge.params.hpp
@@ -1,0 +1,31 @@
+/******************************************************************************
+ * Copyright © 2013-2022 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+namespace mm2::api
+{
+    struct utxo_merge_params
+    {
+        std::size_t merge_at;
+        std::size_t check_every;
+        std::size_t max_merge_at_once;
+    };
+
+    void to_json(nlohmann::json& j, const utxo_merge_params& cfg);
+}

--- a/src/core/atomicdex/config/coins.cfg.cpp
+++ b/src/core/atomicdex/config/coins.cfg.cpp
@@ -33,6 +33,11 @@ namespace atomic_dex
         {
             cfg.custom_backup = j.at("mm2_backup");
         }
+        
+        if (j.contains("utxo_merge"))
+        {
+            cfg.utxo_merge = j.at("utxo_merge");
+        }
         if (j.contains("electrum"))
         {
             cfg.electrum_urls = j.at("electrum").get<std::vector<electrum_server>>();

--- a/src/core/atomicdex/config/coins.cfg.hpp
+++ b/src/core/atomicdex/config/coins.cfg.hpp
@@ -27,6 +27,7 @@
 
 //! Project
 #include "atomicdex/api/mm2/mm2.constants.hpp"
+#include "atomicdex/api/mm2/utxo.merge.params.hpp"
 #include "atomicdex/config/electrum.cfg.hpp"
 #include "atomicdex/constants/qt.coins.enums.hpp"
 
@@ -39,34 +40,35 @@ namespace atomic_dex
         static constexpr const char* matic_gas_stations = "https://gasstation-mainnet.matic.network/";
         using electrum_servers                          = std::vector<electrum_server>;
         using nodes                                     = std::vector<std::string>;
-        std::string                     ticker;
-        std::optional<std::string>      alias_ticker{std::nullopt};
-        std::string                     gui_ticker; ///< Ticker displayed in the gui
-        std::string                     name;       ///< nice name
-        std::optional<electrum_servers> electrum_urls;
-        std::optional<nodes>            urls;
-        bool                            is_claimable{false};
-        std::string                     minimal_claim_amount{"0"};
-        bool                            currently_enabled{false};
-        bool                            active{false};
-        std::string                     coinpaprika_id{"test-coin"};
-        std::string                     coingecko_id{"test-coin"};
-        std::string                     nomics_id{"test-coin"};
-        bool                            is_custom_coin{false};
-        std::string                     type;
-        std::vector<std::string>        explorer_url; ///< usefull for transaction, take this url and append transaction id
-        std::string                     tx_uri{"tx/"};
-        std::string                     address_url{"address/"};
-        std::optional<nlohmann::json>   custom_backup;
-        std::optional<bool>             is_testnet{false}; ///< True if testnet (tBTC, tQTUM, QRC-20 on testnet, tETH)
-        CoinType                        coin_type;
-        bool                            checked{false};
-        bool                            wallet_only{false};
-        bool                            has_parent_fees_ticker{false}; ///< True if parent fees is different from current ticker eg: ERC20 tokens
-        std::string                     fees_ticker;
-        bool                            segwit{false};
-        bool                            is_segwit_on{false};
-        bool                            is_erc_family{false};
+        std::string                      ticker;
+        std::optional<std::string>       alias_ticker{std::nullopt};
+        std::string                      gui_ticker; ///< Ticker displayed in the gui
+        std::string                      name;       ///< nice name
+        std::optional<electrum_servers>  electrum_urls;
+        std::optional<bool>              utxo_merge{false};
+        std::optional<nodes>             urls;
+        bool                             is_claimable{false};
+        std::string                      minimal_claim_amount{"0"};
+        bool                             currently_enabled{false};
+        bool                             active{false};
+        std::string                      coinpaprika_id{"test-coin"};
+        std::string                      coingecko_id{"test-coin"};
+        std::string                      nomics_id{"test-coin"};
+        bool                             is_custom_coin{false};
+        std::string                      type;
+        std::vector<std::string>         explorer_url; ///< usefull for transaction, take this url and append transaction id
+        std::string                      tx_uri{"tx/"};
+        std::string                      address_url{"address/"};
+        std::optional<nlohmann::json>    custom_backup;
+        std::optional<bool>              is_testnet{false}; ///< True if testnet (tBTC, tQTUM, QRC-20 on testnet, tETH)
+        CoinType                         coin_type;
+        bool                             checked{false};
+        bool                             wallet_only{false};
+        bool                             has_parent_fees_ticker{false}; ///< True if parent fees is different from current ticker eg: ERC20 tokens
+        std::string                      fees_ticker;
+        bool                             segwit{false};
+        bool                             is_segwit_on{false};
+        bool                             is_erc_family{false};
     };
 
     void from_json(const nlohmann::json& j, coin_config& cfg);

--- a/src/core/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.cpp
@@ -644,7 +644,7 @@ namespace atomic_dex
 
                 if (coin_info.utxo_merge.value_or(false))
                 {
-                    t_utxo_merge_params params{.merge_at = 300, .check_every = 60, .max_merge_at_once = 200};
+                    t_utxo_merge_params params{.merge_at = 250, .check_every = 300, .max_merge_at_once = 125};
                     nlohmann::json             j;
                     mm2::api::to_json(j, params);
                     request.merge_params     = j;

--- a/src/core/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.cpp
@@ -651,7 +651,6 @@ namespace atomic_dex
                 }
                 nlohmann::json j = ::mm2::api::template_request("electrum");
                 ::mm2::api::to_json(j, request);
-                // SPDLOG_INFO("electrum request: {}", j.dump(4));
                 batch_array.push_back(j);
             }
             else
@@ -664,7 +663,6 @@ namespace atomic_dex
                     .with_tx_history = false};
                 nlohmann::json j = ::mm2::api::template_request("enable");
                 ::mm2::api::to_json(j, request);
-                // SPDLOG_INFO("enable request: {}", j.dump(4));
                 batch_array.push_back(j);
             }
             //! If the coin is a custom coin and not present, then we have a config mismatch, we re-add it to the mm2 coins cfg but this need a app restart.

--- a/src/core/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.cpp
@@ -641,6 +641,13 @@ namespace atomic_dex
                     request.address_format                   = nlohmann::json::object();
                     request.address_format.value()["format"] = "segwit";
                 }
+                if (coin_info.utxo_merge_params.value_or(false))
+                {
+                    request.utxo_merge_params                   = nlohmann::json::object();
+                    request.utxo_merge_params.value()["merge_at"] = 300;
+                    request.utxo_merge_params.value()["check_every"] = 600;
+                    request.utxo_merge_params.value()["max_merge_at_once"] = 200;
+                }
                 nlohmann::json j = ::mm2::api::template_request("electrum");
                 ::mm2::api::to_json(j, request);
                 batch_array.push_back(j);

--- a/src/core/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.cpp
@@ -641,15 +641,17 @@ namespace atomic_dex
                     request.address_format                   = nlohmann::json::object();
                     request.address_format.value()["format"] = "segwit";
                 }
-                if (coin_info.utxo_merge_params.value_or(false))
+
+                if (coin_info.utxo_merge.value_or(false))
                 {
-                    request.utxo_merge_params                   = nlohmann::json::object();
-                    request.utxo_merge_params.value()["merge_at"] = 300;
-                    request.utxo_merge_params.value()["check_every"] = 600;
-                    request.utxo_merge_params.value()["max_merge_at_once"] = 200;
+                    t_utxo_merge_params params{.merge_at = 300, .check_every = 60, .max_merge_at_once = 200};
+                    nlohmann::json             j;
+                    mm2::api::to_json(j, params);
+                    request.merge_params     = j;
                 }
                 nlohmann::json j = ::mm2::api::template_request("electrum");
                 ::mm2::api::to_json(j, request);
+                SPDLOG_INFO("electrum request: {}", j.dump(4));
                 batch_array.push_back(j);
             }
             else

--- a/src/core/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.cpp
@@ -651,7 +651,7 @@ namespace atomic_dex
                 }
                 nlohmann::json j = ::mm2::api::template_request("electrum");
                 ::mm2::api::to_json(j, request);
-                SPDLOG_INFO("electrum request: {}", j.dump(4));
+                // SPDLOG_INFO("electrum request: {}", j.dump(4));
                 batch_array.push_back(j);
             }
             else

--- a/src/tests/api/mm2/mm2.api.utxo.merge.params.tests.cpp
+++ b/src/tests/api/mm2/mm2.api.utxo.merge.params.tests.cpp
@@ -1,0 +1,36 @@
+/******************************************************************************
+ * Copyright © 2013-2022 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+//! Deps
+#include "doctest/doctest.h"
+#include <nlohmann/json.hpp>
+
+#include "atomicdex/api/mm2/utxo.merge.params.hpp"
+
+TEST_CASE("mm2::api::utxo_merge_params serialisation")
+{
+    const nlohmann::json     expected_json = R"(
+    {
+      "merge_at":50,
+      "check_every":10,
+      "max_merge_at_once":25
+    }
+    )"_json;
+    mm2::api::utxo_merge_params request{.merge_at = 50, .check_every = 10, .max_merge_at_once = 25};
+    nlohmann::json           j;
+    mm2::api::to_json(j, request);
+    CHECK_EQ(j, expected_json);
+}


### PR DESCRIPTION
Related to https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1784

Currently this is only manually configurable by adding `"utxo_merge": true` to a coins config (e.g. in 0.5.6-coins-username.json)
It will only work for UTXO coins.

In future, we can allow this to be configured thru the gui settings.

@gcharang - hopefully this will make explaining how to recover an address from bulk mining utxos a little simpler to the non-technical users.