### PR TITLE
Handle errors gracefully

### DIFF
--- a/atomic_defi_design/Dex/NewUpdateModal.qml
+++ b/atomic_defi_design/Dex/NewUpdateModal.qml
@@ -157,7 +157,7 @@ Dex.MultipageModal
                 }
                 else
                 {
-                    console.error(Dex.API.app.updateCheckerService.udpateInfo.status)
+                    console.error(Dex.API.app.updateCheckerService.updateInfo.status)
                 }
             }
         }

--- a/src/core/atomicdex/services/price/global.provider.cpp
+++ b/src/core/atomicdex/services/price/global.provider.cpp
@@ -210,16 +210,22 @@ namespace atomic_dex
                 {
                     t_float_50 rate(1);
                     {
-                        std::shared_lock lock(m_coin_rate_mutex);
-                        rate = t_float_50(m_coin_rate_providers.at(fiat)); ///< Retrieve BTC or KMD rate let's say for USD
+                        if (m_coin_rate_providers.contains(fiat))
+                        {
+                            std::shared_lock lock(m_coin_rate_mutex);
+                            rate = t_float_50(m_coin_rate_providers.at(fiat)); ///< Retrieve BTC or KMD rate let's say for USD
+                        }
                     }
                     t_float_50 tmp_current_price = t_float_50(current_price) * rate;
                     current_price                = tmp_current_price.str();
                 }
                 else if (fiat != "USD")
                 {
-                    t_float_50 tmp_current_price = t_float_50(current_price) * m_other_fiats_rates->at("rates").at(fiat).get<double>();
-                    current_price                = tmp_current_price.str();
+                    if (m_other_fiats_rates->contains("rates"))
+                    {
+                        t_float_50 tmp_current_price = t_float_50(current_price) * m_other_fiats_rates->at("rates").at(fiat).get<double>();
+                        current_price                = tmp_current_price.str();
+                    }
                 }
             }
             else
@@ -227,8 +233,11 @@ namespace atomic_dex
                 //! We use oracle
                 if (is_this_currency_a_fiat(m_cfg, fiat) && fiat != "USD")
                 {
-                    t_float_50 tmp_current_price = t_float_50(current_price) * m_other_fiats_rates->at("rates").at(fiat).get<double>();
-                    current_price                = tmp_current_price.str();
+                    if (m_other_fiats_rates->contains("rates"))
+                    {
+                        t_float_50 tmp_current_price = t_float_50(current_price) * m_other_fiats_rates->at("rates").at(fiat).get<double>();
+                        current_price                = tmp_current_price.str();
+                    }
                 }
 
                 else if (!is_this_currency_a_fiat(m_cfg, fiat) && is_oracle_ready)
@@ -264,6 +273,7 @@ namespace atomic_dex
             SPDLOG_ERROR("Exception caught in get_rate_conversion: {} - fiat: {} - ticker: {}", error.what(), fiat, ticker);
             return "0.00";
         }
+        return "0.00";
     }
 
     std::string


### PR DESCRIPTION
On login, sometimes prices are not yet available and this error floods the logs
![image](https://user-images.githubusercontent.com/35845239/187876681-f2dcc5d5-f265-4d28-ae35-575826ae1393.png)

This PR handles the error without an exception log message.

There was another "on launch" error relating to app update status, it was due to a misspelled variable, which is also fixed in this PR.