### PR TITLE
Add SSL electrum servers for RICK / MORTY / KMD

### DIFF
--- a/assets/config/0.5.6-coins.json
+++ b/assets/config/0.5.6-coins.json
@@ -5483,6 +5483,18 @@
       {
         "url": "electrum1.cipig.net:10001",
         "ws_url": "electrum1.cipig.net:30001"
+      },
+      {
+        "url": "electrum3.cipig.net:20001",
+        "protocol": "SSL"
+      },
+      {
+        "url": "electrum2.cipig.net:20001",
+        "protocol": "SSL"
+      },
+      {
+        "url": "electrum1.cipig.net:20001",
+        "protocol": "SSL"
       }
     ],
     "explorer_url": [
@@ -5805,6 +5817,18 @@
       {
         "url": "electrum1.cipig.net:10017",
         "ws_url": "electrum1.cipig.net:30017"
+      },
+      {
+        "url": "electrum3.cipig.net:20017",
+        "protocol": "SSL"
+      },
+      {
+        "url": "electrum2.cipig.net:20017",
+        "protocol": "SSL"
+      },
+      {
+        "url": "electrum1.cipig.net:20017",
+        "protocol": "SSL"
       }
     ],
     "explorer_url": [
@@ -5832,6 +5856,18 @@
       {
         "url": "electrum1.cipig.net:10018",
         "ws_url": "electrum1.cipig.net:30018"
+      },
+      {
+        "url": "electrum3.cipig.net:20018",
+        "protocol": "SSL"
+      },
+      {
+        "url": "electrum2.cipig.net:20018",
+        "protocol": "SSL"
+      },
+      {
+        "url": "electrum1.cipig.net:20018",
+        "protocol": "SSL"
       }
     ],
     "explorer_url": [


### PR DESCRIPTION
ref: https://github.com/KomodoPlatform/AtomicDEX-mobile/pull/1647

To test:
- [ ] activate KMD
- [ ] activate RICK
- [ ] activate MORTY