### PR TITLE
update coins file, fix logic

### DIFF
--- a/assets/config/0.5.6-coins.json
+++ b/assets/config/0.5.6-coins.json
@@ -848,51 +848,6 @@
     "active": false,
     "currently_enabled": false
   },
-  "BCH": {
-    "coin": "BCH",
-    "coingecko_id": "bitcoin-cash",
-    "coinpaprika_id": "bch-bitcoin-cash",
-    "nomics_id": "BCH",
-    "active": false,
-    "currently_enabled": false,
-    "electrum": [
-      {
-        "url": "electrum1.cipig.net:10055",
-        "ws_url": "electrum1.cipig.net:30055"
-      },
-      {
-        "url": "electrum2.cipig.net:10055",
-        "ws_url": "electrum2.cipig.net:30055"
-      },
-      {
-        "url": "electrum3.cipig.net:10055",
-        "ws_url": "electrum3.cipig.net:30055"
-      }
-    ],
-    "explorer_url": [
-      "https://explorer.bitcoin.com/bch/"
-    ],
-    "bchd_urls": [
-      "https://bchd.fountainhead.cash:443"
-    ],
-    "allow_slp_unsafe_conf": false,
-    "type": "UTXO",
-    "other_types": ["SLP"],
-    "name": "Bitcoin Cash"
-  },
-  "USDT-SLP": {
-    "coin": "USDT-SLP",
-    "active": false,
-    "coingecko_id": "tether",
-    "coinpaprika_id": "usdt-tether",
-    "currently_enabled": false,
-    "explorer_url": [
-      "https://simpleledger.info/"
-    ],
-    "explorer_tx_url": "#tx/",
-    "type": "SLP",
-    "name": "Tether"
-  },
   "BCH-ERC20": {
     "coin": "BCH-ERC20",
     "name": "Bitcoin Cash",
@@ -10760,34 +10715,6 @@
     "currently_enabled": false,
     "wallet_only": false
   },
-  "sTST": {
-    "coin": "sTST",
-    "active": false,
-    "is_testnet": true,
-    "coingecko_id": "test-coin",
-    "coinpaprika_id": "test-coin",
-    "currently_enabled": false,
-    "explorer_url": [
-      "https://testnet.simpleledger.info/"
-    ],
-    "explorer_tx_url": "#tx/",
-    "type": "SLP",
-    "name": "sTST"
-  },
-  "USDF": {
-    "coin": "USDF",
-    "active": false,
-    "is_testnet": true,
-    "coingecko_id": "test-coin",
-    "coinpaprika_id": "test-coin",
-    "currently_enabled": false,
-    "explorer_url": [
-      "https://testnet.simpleledger.info/"
-    ],
-    "explorer_tx_url": "#tx/",
-    "type": "SLP",
-    "name": "Fake USD (Testnet)"
-  },
   "tBCH": {
     "coin": "tBCH",
     "active": false,
@@ -10819,5 +10746,104 @@
     "type": "UTXO",
     "other_types": ["SLP"],
     "name": "Bitcoin Cash (Testnet)"
+  },
+  "sTST": {
+    "coin": "sTST",
+    "active": false,
+    "is_testnet": true,
+    "coingecko_id": "test-coin",
+    "coinpaprika_id": "test-coin",
+    "currently_enabled": false,
+    "explorer_url": [
+      "https://testnet.simpleledger.info/"
+    ],
+    "explorer_tx_url": "#tx/",
+    "type": "SLP",
+    "name": "sTST"
+  },
+  "USDF": {
+    "coin": "USDF",
+    "active": false,
+    "is_testnet": true,
+    "coingecko_id": "test-coin",
+    "coinpaprika_id": "test-coin",
+    "currently_enabled": false,
+    "explorer_url": [
+      "https://testnet.simpleledger.info/"
+    ],
+    "explorer_tx_url": "#tx/",
+    "type": "SLP",
+    "name": "Fake USD (Testnet)"
+  },
+  "BCH": {
+    "coin": "BCH",
+    "coingecko_id": "bitcoin-cash",
+    "coinpaprika_id": "bch-bitcoin-cash",
+    "nomics_id": "BCH",
+    "active": false,
+    "currently_enabled": false,
+    "electrum": [
+      {
+        "url": "electrum1.cipig.net:10055",
+        "ws_url": "electrum1.cipig.net:30055"
+      },
+      {
+        "url": "electrum2.cipig.net:10055",
+        "ws_url": "electrum2.cipig.net:30055"
+      },
+      {
+        "url": "electrum3.cipig.net:10055",
+        "ws_url": "electrum3.cipig.net:30055"
+      }
+    ],
+    "explorer_url": [
+      "https://explorer.bitcoin.com/bch/"
+    ],
+    "bchd_urls": [
+      "https://bchd.fountainhead.cash:443"
+    ],
+    "allow_slp_unsafe_conf": false,
+    "type": "UTXO",
+    "other_types": ["SLP"],
+    "name": "Bitcoin Cash"
+  },
+  "HONK": {
+    "coin": "HONK",
+    "active": false,
+    "coingecko_id": "test-coin",
+    "coinpaprika_id": "test-coin",
+    "currently_enabled": false,
+    "explorer_url": [
+      "https://simpleledger.info/"
+    ],
+    "explorer_tx_url": "#tx/",
+    "type": "SLP",
+    "name": "HONK HONK"
+  },
+  "ASLP": {
+    "coin": "ASLP",
+    "active": false,
+    "coingecko_id": "test-coin",
+    "coinpaprika_id": "test-coin",
+    "currently_enabled": false,
+    "explorer_url": [
+      "https://simpleledger.info/"
+    ],
+    "explorer_tx_url": "#tx/",
+    "type": "SLP",
+    "name": "AtomicSLP"
+  },
+  "USDT-SLP": {
+    "coin": "USDT-SLP",
+    "active": false,
+    "coingecko_id": "tether",
+    "coinpaprika_id": "usdt-tether",
+    "currently_enabled": false,
+    "explorer_url": [
+      "https://simpleledger.info/"
+    ],
+    "explorer_tx_url": "#tx/",
+    "type": "SLP",
+    "name": "Tether"
   }
 }

--- a/src/core/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.cpp
@@ -508,7 +508,7 @@ namespace atomic_dex
             }
             else if (coin_config.coin_type == CoinType::SLP || (coin_config.other_types && coin_config.other_types->contains(CoinType::SLP)))
             {
-                if (coin_config.is_testnet)
+                if (coin_config.is_testnet.value_or(false))
                 {
                     slp_testnet_coins.push_back(coin_config);
                 }


### PR DESCRIPTION
Thanks @cipig for reporting BCH no longer enabling in dev.
Once https://github.com/KomodoPlatform/coins/pull/493 is merged, I'll rerun CI to test this.

- [ ] Can enable tBCH & BCH
- [ ] Can enable SLP tokens

To test locally, you can change https://github.com/KomodoPlatform/atomicDEX-Desktop/blob/dev/CMakeLists.txt#L82 
and use `https://github.com/KomodoPlatform/coins/archive/slptokens.zip`