### PR TITLE
use v2 request format for bestorders

### DIFF
--- a/src/core/atomicdex/services/price/orderbook.scanner.service.cpp
+++ b/src/core/atomicdex/services/price/orderbook.scanner.service.cpp
@@ -60,7 +60,7 @@ namespace atomic_dex
 
                 //! Prepare request
                 nlohmann::json batch                = nlohmann::json::array();
-                nlohmann::json best_orders_req_json = mm2::template_request("best_orders");
+                nlohmann::json best_orders_req_json = mm2::template_request("best_orders", true);
                 to_json(best_orders_req_json, req);
                 batch.push_back(best_orders_req_json);
 


### PR DESCRIPTION
Not sure how this crept back in, but seen it before and easy to fix. Thanks @cipig  for reporting.
To test, go to dex pro view, and select a common traded pair. If you can see items listed in the best orders panel, its working.