### PR TITLE
Remove deprecated testnets and coins

### DIFF
--- a/assets/config/0.5.6-coins.json
+++ b/assets/config/0.5.6-coins.json
@@ -3702,22 +3702,6 @@
     "active": false,
     "currently_enabled": false
   },
-  "JSTR": {
-    "coin": "JSTR",
-    "name": "Ropsten test ERC20",
-    "coinpaprika_id": "test-coin",
-    "coingecko_id": "test-coin",
-    "is_testnet": true,
-    "nodes": [
-      "https://ropsten.infura.io/v3/1d059a9aca7d49a3a380c71068bffb1c"
-    ],
-    "explorer_url": [
-      "https://ropsten.etherscan.io/"
-    ],
-    "type": "ERC-20",
-    "active": false,
-    "currently_enabled": false
-  },
   "JUMBLR": {
     "coin": "JUMBLR",
     "name": "JUMBLR",
@@ -4827,56 +4811,6 @@
     ],
     "type": "Arbitrum",
     "name": "Ethereum"
-  },
-  "ETHK-OPT20": {
-    "active": false,
-    "wallet_only": true,
-    "coin": "ETHK-OPT20",
-    "coingecko_id": "test-coin",
-    "coinpaprika_id": "test-coin",
-    "currently_enabled": false,
-    "is_testnet": true,
-    "nodes": [
-      "https://kovan.optimism.io"
-    ],
-    "explorer_url": [
-      "https://kovan-optimistic.etherscan.io/"
-    ],
-    "type": "Optimism",
-    "name": "EthKovan Optimism (Testnet)"
-  },
-  "ETHR-ARB20": {
-    "active": false,
-    "wallet_only": true,
-    "coin": "ETHR-ARB20",
-    "coingecko_id": "test-coin",
-    "coinpaprika_id": "test-coin",
-    "currently_enabled": false,
-    "is_testnet": true,
-    "nodes": [
-      "https://rinkeby.arbitrum.io/rpc"
-    ],
-    "explorer_url": [
-      "https://rinkeby-explorer.arbitrum.io/#/"
-    ],
-    "type": "Arbitrum",
-    "name": "EthRinkeby Arbitrum (Testnet)"
-  },
-  "ETHR": {
-    "active": false,
-    "coin": "ETHR",
-    "coingecko_id": "test-coin",
-    "coinpaprika_id": "test-coin",
-    "currently_enabled": false,
-    "is_testnet": true,
-    "nodes": [
-      "https://ropsten.infura.io/v3/1d059a9aca7d49a3a380c71068bffb1c"
-    ],
-    "explorer_url": [
-      "https://ropsten.etherscan.io/"
-    ],
-    "type": "ERC-20",
-    "name": "Ethereum Ropsten (Testnet)"
   },
   "UIS": {
     "coin": "UIS",

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -85,9 +85,12 @@ namespace atomic_dex
                 !coins.contains(QString::fromStdString(coin_info.fees_ticker)))
             {
                 auto coin_parent_info = mm2.get_coin_info(coin_info.fees_ticker);
-                if (!coin_parent_info.currently_enabled && !coin_parent_info.active && extra_coins.insert(coin_parent_info.ticker).second)
+                if (coin_parent_info.ticker != "")
                 {
-                    SPDLOG_INFO("Adding extra coin: {} to enable", coin_parent_info.ticker);
+                    if (!coin_parent_info.currently_enabled && !coin_parent_info.active && extra_coins.insert(coin_parent_info.ticker).second)
+                    {
+                        SPDLOG_INFO("Adding extra coin: {} to enable", coin_parent_info.ticker);
+                    }
                 }
             }
             coins_std.push_back(coin.toStdString());

--- a/src/core/atomicdex/api/mm2/rpc.enable.cpp
+++ b/src/core/atomicdex/api/mm2/rpc.enable.cpp
@@ -51,17 +51,15 @@ namespace atomic_dex::mm2
         case CoinType::Optimism:
         {
             j["urls"]                  = cfg.urls;
-            j["swap_contract_address"] = cfg.is_testnet ? cfg.optimism_erc_testnet_swap_contract_address : cfg.optimism_erc_swap_contract_address;
-            j["fallback_swap_contract"] =
-                cfg.is_testnet ? cfg.optimism_erc_testnet_fallback_swap_contract_address : cfg.optimism_erc_fallback_swap_contract_address;
+            j["swap_contract_address"] = cfg.optimism_erc_swap_contract_address;
+            j["fallback_swap_contract"] = cfg.optimism_erc_fallback_swap_contract_address;
             break;
         }
         case CoinType::Arbitrum:
         {
             j["urls"]                  = cfg.urls;
-            j["swap_contract_address"] = cfg.is_testnet ? cfg.arbitrum_erc_testnet_swap_contract_address : cfg.arbitrum_erc_swap_contract_address;
-            j["fallback_swap_contract"] =
-                cfg.is_testnet ? cfg.arbitrum_erc_testnet_fallback_swap_contract_address : cfg.arbitrum_erc_fallback_swap_contract_address;
+            j["swap_contract_address"] = cfg.arbitrum_erc_swap_contract_address;
+            j["fallback_swap_contract"] = cfg.arbitrum_erc_fallback_swap_contract_address;
             break;
         }
         case CoinType::BEP20:

--- a/src/core/atomicdex/api/mm2/rpc.enable.hpp
+++ b/src/core/atomicdex/api/mm2/rpc.enable.hpp
@@ -77,12 +77,8 @@ namespace atomic_dex::mm2
         const std::string        matic_erc_testnet_fallback_swap_contract_address{"0x73c1Dd989218c3A154C71Fc08Eb55A24Bd2B3A10"};
         const std::string        optimism_erc_swap_contract_address{"0x9130b257d37a52e52f21054c4da3450c72f595ce"};
         const std::string        optimism_erc_fallback_swap_contract_address{"0x9130b257d37a52e52f21054c4da3450c72f595ce"};
-        const std::string        optimism_erc_testnet_swap_contract_address{"0x9130b257d37a52e52f21054c4da3450c72f595ce"};
-        const std::string        optimism_erc_testnet_fallback_swap_contract_address{"0x9130b257d37a52e52f21054c4da3450c72f595ce"};
         const std::string        arbitrum_erc_swap_contract_address{"0x9130b257d37a52e52f21054c4da3450c72f595ce"};
         const std::string        arbitrum_erc_fallback_swap_contract_address{"0x9130b257d37a52e52f21054c4da3450c72f595ce"};
-        const std::string        arbitrum_erc_testnet_swap_contract_address{"0x9130b257d37a52e52f21054c4da3450c72f595ce"};
-        const std::string        arbitrum_erc_testnet_fallback_swap_contract_address{"0x9130b257d37a52e52f21054c4da3450c72f595ce"};
         const std::string        sbch_erc_swap_contract_address{"0x25bF2AAB8749AD2e4360b3e0B738f3Cd700C4D68"};
         const std::string        sbch_erc_fallback_swap_contract_address{"0x25bF2AAB8749AD2e4360b3e0B738f3Cd700C4D68"};
         const std::string        sbch_erc_testnet_swap_contract_address{"0x25bF2AAB8749AD2e4360b3e0B738f3Cd700C4D68"};

--- a/src/core/atomicdex/config/coins.cfg.cpp
+++ b/src/core/atomicdex/config/coins.cfg.cpp
@@ -109,7 +109,9 @@ namespace
         {
             return CoinType::ZHTLC;
         }
-        throw std::invalid_argument{"Undefined given coin type."};
+        SPDLOG_INFO("Invalid coin type: {}", coin_type);
+        return CoinType::Invalid;
+        // throw std::invalid_argument{"Undefined given coin type."};
     }
 }
 
@@ -222,12 +224,12 @@ namespace atomic_dex
             break;
         case CoinType::Optimism:
             cfg.has_parent_fees_ticker = true;
-            cfg.fees_ticker            = cfg.is_testnet.value() ? "ETHK-OPT20" : "ETH-OPT20";
+            cfg.fees_ticker            = "ETH-OPT20";
             cfg.is_erc_family          = true;
             break;
         case CoinType::Arbitrum:
             cfg.has_parent_fees_ticker = true;
-            cfg.fees_ticker            = cfg.is_testnet.value() ? "ETHR-ARB20" : "ETH-ARB20";
+            cfg.fees_ticker            = "ETH-ARB20";
             cfg.is_erc_family          = true;
             break;
         case CoinType::AVX20:
@@ -292,6 +294,10 @@ namespace atomic_dex
         case CoinType::ZHTLC:
             cfg.has_parent_fees_ticker = false;
             cfg.is_zhtlc_family        = true;
+            cfg.fees_ticker            = cfg.ticker;
+            break;
+        case CoinType::Invalid:
+            cfg.has_parent_fees_ticker = false;
             cfg.fees_ticker            = cfg.ticker;
             break;
         default:

--- a/src/core/atomicdex/constants/qt.coins.enums.hpp
+++ b/src/core/atomicdex/constants/qt.coins.enums.hpp
@@ -53,8 +53,9 @@ namespace atomic_dex
             RSK             = 19,
             ZHTLC           = 20,
             Disabled        = 21,
-            All             = 22,
-            Size            = 23
+            Invalid         = 22,
+            All             = 23,
+            Size            = 24
         };
 
         Q_ENUM(CoinTypeEnum)


### PR DESCRIPTION
ann ref: https://twitter.com/infura_io/status/1575138372884070400
coins repo ref: https://github.com/KomodoPlatform/coins/pull/496
To test:
- Launch app, then try and enable any ARB or OPT assets. App should not crash if attempting to enable coins which were removed (before assets reset).
- Reset assets, and try to enable ARB assets. There should be no OPT assets listed. 

Closes https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1989