### PR TITLE
fix chart from bestorders bug

### DIFF
--- a/atomic_defi_design/Dex/Exchange/ProView/Chart.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/Chart.qml
@@ -6,6 +6,7 @@ import QtWebEngine 1.8
 import "../../Components"
 import "../../Constants"
 import Dex.Themes 1.0 as Dex
+import AtomicDEX.MarketMode 1.0
 
 Item
 {
@@ -184,7 +185,14 @@ Item
         target: app
         function onPairChanged(left, right)
         {
-            root.loadChart(left, right)
+            if (API.app.trading_pg.market_mode == MarketMode.Sell)
+            {
+                root.loadChart(left, right)
+            }
+            else
+            {
+                root.loadChart(right, left)
+            }
         }
     }
 

--- a/atomic_defi_design/Dex/Exchange/ProView/Chart.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/Chart.qml
@@ -182,9 +182,9 @@ Item
     Connections
     {
         target: app
-        function onPairChanged()
+        function onPairChanged(left, right)
         {
-            root.loadChart(left_ticker, right_ticker)
+            root.loadChart(left, right)
         }
     }
 

--- a/atomic_defi_design/Dex/Exchange/Trade/BestOrder/ListDelegate.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/BestOrder/ListDelegate.qml
@@ -170,7 +170,7 @@ Item
                 placeOrderForm.visible = General.flipFalse(placeOrderForm.visible)
                 if (API.app.trading_pg.market_mode == MarketMode.Buy)
                 {
-                    app.pairChanged(rel_ticker, coin)
+                    app.pairChanged(coin, rel_ticker)
                 }
                 else
                 {


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/1915
To test:
- Load app, go to pro dex view. Select order in best orders in sell mode, confirm correct chart loads
- Select order in best orders in buy mode, confirm correct chart loads
- change right combo coin selected, confirm correct chart loads
- change left combo coin selected, confirm correct chart loads
- flip left / right coins with icon between combos, confirm correct chart loads