### PR TITLE
show activated if activated

### DIFF
--- a/atomic_defi_design/Dex/Dashboard/NotificationsModal.qml
+++ b/atomic_defi_design/Dex/Dashboard/NotificationsModal.qml
@@ -242,6 +242,8 @@ DexPopup
         const change = General.formatFullCrypto("", amount, ticker, "", "", true)
         if (!app.segwit_on)
         {
+            if (amount != 0)
+            {
             newNotification("onBalanceUpdateStatus",
                 {
                     am_i_sender,
@@ -255,6 +257,7 @@ DexPopup
                 qsTr("Your wallet balance changed"),
                 human_date,
                 "open_wallet_page")
+            }
         }
         else
         {

--- a/src/core/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.cpp
@@ -586,8 +586,8 @@ namespace atomic_dex
                                 coins.size(), answers.size());
                             if (error.find("already initialized") != std::string::npos)
                             {
+                                SPDLOG_INFO("{} {}: ", coins[idx].ticker, error);
                                 activated_coins.push_back(std::move(coins[idx]));
-                                SPDLOG_ERROR(error);
                             }
                             else
                             {
@@ -684,8 +684,8 @@ namespace atomic_dex
                                 coins.size(), answers.size());
                             if (error.find("already initialized") != std::string::npos)
                             {
+                                SPDLOG_INFO("{} {}: ", coins[idx].ticker, error);
                                 activated_coins.push_back(std::move(coins[idx]));
-                                SPDLOG_ERROR(error);
                             }
                             else
                             {
@@ -773,19 +773,27 @@ namespace atomic_dex
         {
             if (rpc.error)
             {
-                SPDLOG_ERROR(rpc.error->error);
-                SPDLOG_ERROR(rpc.error->error_type);
                 if (rpc.error->error_type.find("PlatformIsAlreadyActivated") != std::string::npos || rpc.error->error_type.find("TokenIsAlreadyActivated") != std::string::npos)
                 {
-                    SPDLOG_ERROR("{} already initialized: ", rpc.request.ticker);
+                    SPDLOG_ERROR("{} {}: ", rpc.request.ticker, rpc.error->error_type);
                     fetch_single_balance(get_coin_info(rpc.request.ticker));
                     update_coin_active({rpc.request.ticker}, true);
                     m_coins_informations[rpc.request.ticker].currently_enabled = true;
                     dispatcher_.trigger<coin_fully_initialized>(coin_fully_initialized{.tickers = {rpc.request.ticker}});
+                    if constexpr (std::is_same_v<RpcRequest, mm2::enable_bch_with_tokens_rpc>)
+                    {
+                        for (const auto& slp_coin_info : rpc.request.slp_tokens_requests)
+                        {
+                            SPDLOG_ERROR("{} {}: ", slp_coin_info.ticker, rpc.error->error_type);
+                            fetch_single_balance(get_coin_info(slp_coin_info.ticker));
+                            update_coin_active({slp_coin_info.ticker}, true);
+                            m_coins_informations[slp_coin_info.ticker].currently_enabled = true;
+                            dispatcher_.trigger<coin_fully_initialized>(coin_fully_initialized{.tickers = {slp_coin_info.ticker}});
+                        }
+                    }
                 }
                 else
                 {
-                    SPDLOG_ERROR(rpc.error->error);
                     m_coins_informations[rpc.request.ticker].currently_enabled = false;
                     update_coin_active({rpc.request.ticker}, false);
                     this->dispatcher_.trigger<enabling_coin_failed>(rpc.request.ticker, rpc.error->error);
@@ -868,19 +876,27 @@ namespace atomic_dex
         {
             if (rpc.error)
             {
-                SPDLOG_ERROR(rpc.error->error);
-                SPDLOG_ERROR(rpc.error->error_type);
                 if (rpc.error->error_type.find("PlatformIsAlreadyActivated") != std::string::npos || rpc.error->error_type.find("TokenIsAlreadyActivated") != std::string::npos)
                 {
-                    SPDLOG_ERROR("{} already initialized: ", rpc.request.ticker);
+                    SPDLOG_ERROR("{} {}: ", rpc.request.ticker, rpc.error->error_type);
                     fetch_single_balance(get_coin_info(rpc.request.ticker));
                     update_coin_active({rpc.request.ticker}, true);
                     m_coins_informations[rpc.request.ticker].currently_enabled = true;
                     dispatcher_.trigger<coin_fully_initialized>(coin_fully_initialized{.tickers = {rpc.request.ticker}});
+                    if constexpr (std::is_same_v<RpcRequest, mm2::enable_bch_with_tokens_rpc>)
+                    {
+                        for (const auto& slp_coin_info : rpc.request.slp_tokens_requests)
+                        {
+                            SPDLOG_ERROR("{} {}: ", slp_coin_info.ticker, rpc.error->error_type);
+                            fetch_single_balance(get_coin_info(slp_coin_info.ticker));
+                            update_coin_active({slp_coin_info.ticker}, true);
+                            m_coins_informations[slp_coin_info.ticker].currently_enabled = true;
+                            dispatcher_.trigger<coin_fully_initialized>(coin_fully_initialized{.tickers = {slp_coin_info.ticker}});
+                        }
+                    }
                 }
                 else
                 {
-                    SPDLOG_ERROR(rpc.error->error);
                     m_coins_informations[rpc.request.ticker].currently_enabled = false;
                     update_coin_active({rpc.request.ticker}, false);
                     this->dispatcher_.trigger<enabling_coin_failed>(rpc.request.ticker, rpc.error->error);

--- a/src/core/atomicdex/services/mm2/mm2.service.hpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.hpp
@@ -171,6 +171,7 @@ namespace atomic_dex
        void enable_coin(const std::string& ticker);
        void enable_coin(const coin_config& coin_config);
      private:
+       void update_coin_active(const std::vector<std::string>& tickers, bool status);
        void enable_erc_family_coin(const coin_config& coin_config);
        void enable_erc_family_coins(const t_coins& coins);
        void enable_utxo_qrc20_coin(coin_config coin_config);


### PR DESCRIPTION
Fixes a bug where you can't enable a coin because when you do the API response in logs is 
```
[20:48:23] [debug] [mm2.service.cpp:1049] [922060]: error: bad answer json for enable/electrum details: {
    "error": "rpc:212] dispatcher_legacy:160] lp_commands_legacy:121] lp_coins:2270] Coin ZRX-PLG20 already initialized"
}
```
In this case, PR will make sure app adds coin to be visible in portfoilio.
To test:
- launch app, and get rpc password from `settings > security > view seed and private key`
- use rpc password to [activate coins in CLI](https://developers.komodoplatform.com/basic-docs/atomicdex-api-legacy/coin_activation.html). To cover all cases, include at least one of each: UTXO / ERC-20 / SLP / ZHTLC
- Coins will not be visible in app. Select them for enabling from coin activation menu.
- Confirm coin is now visible in portfolio, and when you go to wallet page and click "Receive" it shows correct address and not `Invalid Ticker` (you might see this if you are fast enough, but address should appear within 3-5 sec at most)