### PR TITLE
Reject taproot addresses

### DIFF
--- a/atomic_defi_design/Dex/Wallet/SendModal.qml
+++ b/atomic_defi_design/Dex/Wallet/SendModal.qml
@@ -49,6 +49,11 @@ MultipageModal
     function getCryptoAmount() { return _preparePage.cryptoSendMode ? input_amount.text : equivalentAmount.value }
 
     function prepareSendCoin(address, amount, with_fees, fees_amount, is_special_token, gas_limit, gas_price) {
+        if (address.substring(0,4) == "bc1p" || address.substring(0,4) == "tb1p")
+        {
+            showError(qsTr("Taproot not supported"), "Please enter a standard legacy or segwit address.")
+            return
+        }
         let max = parseFloat(current_ticker_infos.balance) === parseFloat(amount)
 
         // Save for later check


### PR DESCRIPTION
AtomicDEX API is not yet taproot compatible. Until API is patched, we will do the validation on the GUI side.
To test:
- Try and prepare a tBTC send to `tb1p6h5fuzmnvpdthf5shf0qqjzwy7wsqc5rhmgq2ks9xrak4ry6mtrscsqvzp`
- Try and prepare a BTC send to `bc1pp4f0rcxnxah3uupyhv0gqvveh0x92s5dfv0lsvpx0uaffmn2kzhsghme0q`