### PR TITLE
Bypass actions unless needed

### DIFF
--- a/src/core/atomicdex/api/mm2/mm2.client.cpp
+++ b/src/core/atomicdex/api/mm2/mm2.client.cpp
@@ -192,7 +192,7 @@ namespace atomic_dex::mm2
     TAnswer
     mm2_client::process_rpc(TRequest&& request, std::string rpc_command)
     {
-        SPDLOG_INFO("Processing rpc call: {}", rpc_command);
+        SPDLOG_DEBUG("Processing rpc call: {}", rpc_command);
 
         nlohmann::json json_data = mm2::template_request(rpc_command);
 

--- a/src/core/atomicdex/pages/qt.trading.page.cpp
+++ b/src/core/atomicdex/pages/qt.trading.page.cpp
@@ -85,7 +85,7 @@ namespace atomic_dex
             SPDLOG_WARN("{} is wallet only - skipping", base.toStdString());
             return;
         }
-        SPDLOG_INFO("Setting current orderbook: {} / {}", base.toStdString(), rel.toStdString());
+        SPDLOG_DEBUG("Setting current orderbook: {} / {}", base.toStdString(), rel.toStdString());
         auto* market_selector_mdl = get_market_pairs_mdl();
 
         const bool to_change = base != market_selector_mdl->get_left_selected_coin() || rel != market_selector_mdl->get_right_selected_coin();
@@ -96,7 +96,7 @@ namespace atomic_dex
 
         if (to_change)
         {
-            SPDLOG_INFO("set_current_orderbook");
+            SPDLOG_DEBUG("set_current_orderbook");
             this->get_orderbook_wrapper()->clear_orderbook();
             this->clear_forms("set_current_orderbook");
         }
@@ -115,7 +115,7 @@ namespace atomic_dex
     void
     trading_page::on_gui_enter_dex()
     {
-        SPDLOG_INFO("Enter DEX");
+        SPDLOG_DEBUG("Enter DEX");
         dispatcher_.trigger<gui_enter_trading>();
         if (this->m_system_manager.has_system<auto_update_maker_order_service>() && m_system_manager.get_system<mm2_service>().is_orderbook_thread_active())
         {
@@ -149,7 +149,7 @@ namespace atomic_dex
         t_float_50 rel_min_volume_f = safe_float(get_min_trade_vol().toStdString());
         if (is_selected_order)
         {
-            SPDLOG_INFO(
+            SPDLOG_DEBUG(
                 "max_volume: {} volume: {} order_volume: {}, order_volume_8_digit: {}, order_volume_8_digit_extracted: {}", m_max_volume.toStdString(),
                 m_volume.toStdString(), m_preferred_order->at("base_max_volume").get<std::string>(),
                 utils::adjust_precision(m_preferred_order->at("base_max_volume").get<std::string>()),
@@ -181,7 +181,7 @@ namespace atomic_dex
             if (req.is_exact_selected_order_volume)
             {
                 //! Selected order and we keep the exact volume (Basically swallow the order)
-                SPDLOG_INFO("swallowing the order from the orderbook");
+                SPDLOG_DEBUG("swallowing the order from the orderbook");
                 req.volume_numer = m_preferred_order->at("base_max_volume_numer").get<std::string>();
                 req.volume_denom = m_preferred_order->at("base_max_volume_denom").get<std::string>();
             }
@@ -189,14 +189,14 @@ namespace atomic_dex
                 is_max && !req.is_exact_selected_order_volume && m_preferred_order->contains("max_volume_numer") &&
                 m_preferred_order->contains("max_volume_denom"))
             {
-                SPDLOG_INFO("cannot swallow the selected order from the orderbook, use our theoretical max_volume for it");
+                SPDLOG_DEBUG("cannot swallow the selected order from the orderbook, use our theoretical max_volume for it");
                 //! Selected order but we cannot swallow (not enough funds) set our theoretical max_volume_numer and max_volume_denom
                 req.volume_numer = m_preferred_order->at("max_volume_numer").get<std::string>();
                 req.volume_denom = m_preferred_order->at("max_volume_denom").get<std::string>();
             }
             else
             {
-                SPDLOG_INFO("Selected order, but changing manually the volume, use input_volume");
+                SPDLOG_DEBUG("Selected order, but changing manually the volume, use input_volume");
                 req.selected_order_use_input_volume = true;
             }
         }
@@ -207,7 +207,7 @@ namespace atomic_dex
         buy_request["userpass"] = "*******";
 
         //! Answer
-        SPDLOG_INFO("buy_request is : {}", buy_request.dump(4));
+        SPDLOG_DEBUG("buy_request is : {}", buy_request.dump(4));
         auto answer_functor = [this](const web::http::http_response& resp)
         {
             std::string body = TO_STD_STR(resp.extract_string(true).get());
@@ -279,8 +279,8 @@ namespace atomic_dex
         t_float_50 base_min_trade  = safe_float(get_orderbook_wrapper()->get_base_min_taker_vol().toStdString());
         t_float_50 cur_min_trade   = safe_float(get_min_trade_vol().toStdString());
 
-        SPDLOG_INFO("base_min_trade: {}, cur_min_trade: {}", base_min_trade.str(), cur_min_trade.str());
-        SPDLOG_INFO(
+        SPDLOG_DEBUG("base_min_trade: {}, cur_min_trade: {}", base_min_trade.str(), cur_min_trade.str());
+        SPDLOG_DEBUG(
             "volume: {}, orderbook_available_quantity: {}, is_selected_max: {}", m_volume.toStdString(), orderbook_available_quantity.toStdString(),
             is_selected_max);
         t_sell_request req{
@@ -301,7 +301,7 @@ namespace atomic_dex
 
         if (m_current_trading_mode == TradingModeGadget::Simple)
         {
-            SPDLOG_INFO("Simple trading mode, using FillOrKill order");
+            SPDLOG_DEBUG("Simple trading mode, using FillOrKill order");
             req.order_type                 = nlohmann::json::object();
             req.order_type.value()["type"] = "FillOrKill";
             req.min_volume                 = std::optional<std::string>{std::nullopt};
@@ -315,7 +315,7 @@ namespace atomic_dex
         auto max_taker_vol_json_obj = get_orderbook_wrapper()->get_base_max_taker_vol().toJsonObject();
         if (is_selected_order)
         {
-            SPDLOG_INFO(
+            SPDLOG_DEBUG(
                 "The order is a selected order, treating it, input_vol: {} orderbook_max_vol {}", m_volume.toStdString(),
                 orderbook_available_quantity.toStdString());
 
@@ -323,14 +323,14 @@ namespace atomic_dex
 
             if (t_float_50 base_min_vol_orderbook_f = safe_float(base_min_vol_orderbook); cur_min_trade <= base_min_vol_orderbook_f)
             {
-                SPDLOG_INFO("The selected order min_vol input is too low, using null field instead");
+                SPDLOG_DEBUG("The selected order min_vol input is too low, using null field instead");
                 req.min_volume = std::optional<std::string>{std::nullopt};
             }
 
             if (req.is_exact_selected_order_volume)
             {
                 //! Selected order and we keep the exact volume (Basically swallow the order)
-                SPDLOG_INFO("swallowing the order from the orderbook");
+                SPDLOG_DEBUG("swallowing the order from the orderbook");
                 req.volume_numer = m_preferred_order->at("base_max_volume_numer").get<std::string>();
                 req.volume_denom = m_preferred_order->at("base_max_volume_denom").get<std::string>();
             }
@@ -338,13 +338,13 @@ namespace atomic_dex
                                                                                                                                ///< let's forbid it in simple
                                                                                                                                ///< view
             {
-                SPDLOG_INFO("cannot swallow the selected order from the orderbook, use max_taker_volume for it");
+                SPDLOG_DEBUG("cannot swallow the selected order from the orderbook, use max_taker_volume for it");
                 req.volume_denom = max_taker_vol_json_obj["denom"].toString().toStdString();
                 req.volume_numer = max_taker_vol_json_obj["numer"].toString().toStdString();
             }
             else
             {
-                SPDLOG_INFO("Selected order, but changing manually the volume, use input_volume");
+                SPDLOG_DEBUG("Selected order, but changing manually the volume, use input_volume");
                 req.selected_order_use_input_volume = true;
             }
         }
@@ -363,7 +363,7 @@ namespace atomic_dex
         batch.push_back(sell_request);
 
         sell_request["userpass"] = "******";
-        SPDLOG_INFO("sell request: {}", sell_request.dump(4));
+        SPDLOG_DEBUG("sell request: {}", sell_request.dump(4));
         //! Answer
         auto answer_functor = [this](web::http::http_response resp)
         {
@@ -595,7 +595,7 @@ namespace atomic_dex
         if (this->m_market_mode != market_mode)
         {
             this->m_market_mode = market_mode;
-            SPDLOG_INFO("switching market_mode, new mode: {}", m_market_mode == MarketMode::Buy ? "buy" : "sell");
+            SPDLOG_DEBUG("switching market_mode, new mode: {}", m_market_mode == MarketMode::Buy ? "buy" : "sell");
             this->clear_forms("set_market_mode");
             const auto* market_selector_mdl = get_market_pairs_mdl();
             set_current_orderbook(market_selector_mdl->get_left_selected_coin(), market_selector_mdl->get_right_selected_coin());
@@ -662,12 +662,12 @@ namespace atomic_dex
             SPDLOG_WARN("MM2 service not available, required to clear forms - skipping");
             return;
         }
-        SPDLOG_INFO("clearing forms : {}", from.toStdString());
+        SPDLOG_DEBUG("clearing forms : {}", from.toStdString());
 
         if (m_preferred_order.has_value() && m_current_trading_mode == TradingModeGadget::Simple &&
             m_selected_order_status == SelectedOrderGadget::OrderNotExistingAnymore)
         {
-            SPDLOG_INFO("Simple view cancel order, keeping important data");
+            SPDLOG_DEBUG("Simple view cancel order, keeping important data");
             this->set_volume(QString::fromStdString(m_preferred_order->at("initial_input_volume").get<std::string>()));
             const auto max_taker_vol = get_orderbook_wrapper()->get_base_max_taker_vol().toJsonObject()["decimal"].toString();
             this->set_max_volume(max_taker_vol);
@@ -715,7 +715,7 @@ namespace atomic_dex
                 volume = "0";
             }
             m_volume = std::move(volume);
-            SPDLOG_INFO("volume is : [{}]", m_volume.toStdString());
+            SPDLOG_DEBUG("volume is : [{}]", m_volume.toStdString());
 
             this->determine_total_amount();
             emit volumeChanged();
@@ -772,7 +772,7 @@ namespace atomic_dex
                     {
                         auto       available_quantity       = m_preferred_order->at("base_max_volume").get<std::string>();
                         t_float_50 available_quantity_order = safe_float(available_quantity);
-                        SPDLOG_INFO(
+                        SPDLOG_DEBUG(
                             "available_quantity_order: {}, max_volume: {}, max_taker_vol: {}", utils::format_float(safe_float(available_quantity)),
                             get_max_volume().toStdString(), max_taker_vol);
                         if (available_quantity_order < safe_float(max_taker_vol) && !m_preferred_order->at("capped").get<bool>())
@@ -785,7 +785,7 @@ namespace atomic_dex
                         {
                             if (!m_preferred_order->at("capped").get<bool>())
                             {
-                                SPDLOG_INFO("Selected order capping to max_taker_vol because our max_taker_volume is < base_max_volume");
+                                SPDLOG_DEBUG("Selected order capping to max_taker_vol because our max_taker_volume is < base_max_volume");
                                 m_preferred_order.value()["capped"] = true;
                                 this->set_max_volume(QString::fromStdString(max_vol_str));
                             }
@@ -878,7 +878,7 @@ namespace atomic_dex
             auto max_volume = this->get_max_volume();
             if (!max_volume.isEmpty() && max_volume != "0")
             {
-                SPDLOG_INFO("capping volume because {} (volume) > {} (max_volume)", std_volume, max_volume.toStdString());
+                SPDLOG_DEBUG("capping volume because {} (volume) > {} (max_volume)", std_volume, max_volume.toStdString());
                 this->set_volume(get_max_volume());
             }
         }
@@ -1049,7 +1049,7 @@ namespace atomic_dex
         if (auto preferred_order = nlohmann::json::parse(QString(QJsonDocument(QJsonObject::fromVariantMap(price_object)).toJson()).toStdString());
             preferred_order != m_preferred_order)
         {
-            SPDLOG_INFO("preferred_order: {}", preferred_order.dump(-1));
+            SPDLOG_DEBUG("preferred_order: {}", preferred_order.dump(-1));
             m_preferred_order = std::move(preferred_order);
             emit prefferedOrderChanged();
             if (!m_preferred_order->empty() && m_preferred_order->contains("price"))
@@ -1066,7 +1066,7 @@ namespace atomic_dex
                 }
                 else if (this->m_current_trading_mode == TradingModeGadget::Simple && m_preferred_order->contains("initial_input_volume"))
                 {
-                    SPDLOG_INFO("From simple view, using initial_input_volume from selection to use.");
+                    SPDLOG_DEBUG("From simple view, using initial_input_volume from selection to use.");
                     this->set_volume(QString::fromStdString(m_preferred_order->at("initial_input_volume").get<std::string>()));
                 }
                 this->get_orderbook_wrapper()->refresh_best_orders();
@@ -1167,7 +1167,7 @@ namespace atomic_dex
             volume = "0.0001";
         }
 
-        SPDLOG_INFO("get_volume().toStdString(): {}", get_volume().toStdString());
+        SPDLOG_DEBUG("get_volume().toStdString(): {}", get_volume().toStdString());
         t_trade_preimage_request req{
             .base_coin = base,
             .rel_coin = rel,
@@ -1181,13 +1181,13 @@ namespace atomic_dex
         mm2::to_json(preimage_request, req);
         batch.push_back(preimage_request);
         preimage_request["userpass"] = "******";
-        SPDLOG_INFO("trade_preimage request: {}", preimage_request.dump(-1));
+        SPDLOG_DEBUG("trade_preimage request: {}", preimage_request.dump(-1));
 
         this->set_preimage_busy(true);
         auto answer_functor = [this, &mm2](web::http::http_response resp)
         {
             std::string body = TO_STD_STR(resp.extract_string(true).get());
-            SPDLOG_INFO("trade_preimage answer received: {}", body);
+            SPDLOG_DEBUG("trade_preimage answer received: {}", body);
             if (resp.status_code() == web::http::status_codes::OK)
             {
                 auto           answers               = nlohmann::json::parse(body);
@@ -1506,7 +1506,7 @@ namespace atomic_dex
     void
     trading_page::reset_fees()
     {
-        SPDLOG_INFO("reset_fees");
+        SPDLOG_DEBUG("reset_fees");
         this->set_fees(QVariantMap());
         this->determine_error_cases();
     }

--- a/src/core/atomicdex/pages/qt.trading.page.cpp
+++ b/src/core/atomicdex/pages/qt.trading.page.cpp
@@ -76,6 +76,10 @@ namespace atomic_dex
     void
     trading_page::set_current_orderbook(const QString& base, const QString& rel)
     {
+        if (base.toStdString() == "" || rel.toStdString() == "")
+        {
+            return;
+        }
         if (bool is_wallet_only = m_system_manager.get_system<mm2_service>().get_coin_info(base.toStdString()).wallet_only; is_wallet_only)
         {
             SPDLOG_WARN("{} is wallet only - skipping", base.toStdString());

--- a/src/core/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.cpp
@@ -203,6 +203,7 @@ namespace
             ofs_custom.write(QString::fromStdString(custom_cfg_data.dump()).toUtf8());
             ofs_custom.close();
         }
+        SPDLOG_DEBUG("Coins file updated to set {}: {} | tickers: [{}]", field_name, status,  fmt::join(tickers, ", "));
     }
 }
 

--- a/src/core/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.cpp
@@ -435,23 +435,20 @@ namespace atomic_dex
     bool mm2_service::disable_coin(const std::string& ticker, std::error_code& ec)
     {
         coin_config coin_info = get_coin_info(ticker);
-        SPDLOG_INFO("[mm2_service::disable_coin]: {}", ticker);
-
         if (not coin_info.currently_enabled)
         {
-            SPDLOG_INFO("[mm2_service::disable_coin]: {} not currently_enabled", ticker);
+            SPDLOG_DEBUG("[mm2_service::disable_coin]: {} not currently_enabled", ticker);
             return true;
         }
 
         t_disable_coin_request request{.coin = ticker};
 
         auto                   answer = m_mm2_client.rpc_disable_coin(std::move(request));
-        SPDLOG_INFO("mm2_service::disable_coin: {} result: {}", ticker, answer.raw_result);
+        SPDLOG_DEBUG("mm2_service::disable_coin: {} result: {}", ticker, answer.raw_result);
 
         if (answer.error.has_value())
         {
             std::string error = answer.error.value();
-            SPDLOG_INFO("mm2_service::disable_coin: {} error {}", ticker, error);
             if (error.find("such coin") != std::string::npos)
             {
                 ec = dextop_error::disable_unknown_coin;

--- a/src/core/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.cpp
@@ -2077,7 +2077,7 @@ namespace atomic_dex
 
         if (this->m_mm2_running)
         {
-            SPDLOG_INFO("process_orderbook(true)");
+            SPDLOG_DEBUG("process_orderbook(true)");
             process_orderbook(true);
         }
     }

--- a/src/core/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.cpp
@@ -132,6 +132,11 @@ namespace
         {
             return;
         }
+        if (tickers.empty())
+        {
+            SPDLOG_DEBUG("Tickers list empty, skipping update_coin_status");
+            return;
+        }
         SPDLOG_INFO("Update coins status to: {} - field_name: {} - tickers: {}", status, field_name, fmt::join(tickers, ", "));
         fs::path    cfg_path               = atomic_dex::utils::get_atomic_dex_config_folder();
         std::string filename               = std::string(atomic_dex::get_raw_version()) + "-coins." + wallet_name + ".json";


### PR DESCRIPTION
Noticed in logs there were entries like 

` 1123: [21:31:53] [info] [qt.trading.page.cpp:84] [3025865]: Setting current orderbook:  / `

It should be 

` 1129: [20:36:12] [info] [qt.trading.page.cpp:84] [435877]: Setting current orderbook: LTC / USDC-PLG20`

 This PR will ignore these calls if there is an empty base or rel ticker.

There were also cases where an empty list for update was triggering file ops which were unnecessary.