### PR TITLE
Standardise password length limit

### DIFF
--- a/atomic_defi_design/Dex/Components/DexAppPasswordField.qml
+++ b/atomic_defi_design/Dex/Components/DexAppPasswordField.qml
@@ -20,7 +20,7 @@ DexAppTextField
     height: 50
     width: 300
     background.radius: 25
-    max_length: General.max_pw_length
+    max_length: General.max_std_pw_length
     field.echoMode: TextField.Password
     field.font: Qt.font(
     {

--- a/atomic_defi_design/Dex/Components/DexAppPasswordField.qml
+++ b/atomic_defi_design/Dex/Components/DexAppPasswordField.qml
@@ -6,6 +6,7 @@ import Qaterial 1.0 as Qaterial
 
 import App 1.0
 import Dex.Themes 1.0 as Dex
+import "../Constants"
 
 DexAppTextField
 {
@@ -19,7 +20,7 @@ DexAppTextField
     height: 50
     width: 300
     background.radius: 25
-    max_length: 1000
+    max_length: General.max_pw_length
     field.echoMode: TextField.Password
     field.font: Qt.font(
     {

--- a/atomic_defi_design/Dex/Components/DexDialogTextField.qml
+++ b/atomic_defi_design/Dex/Components/DexDialogTextField.qml
@@ -17,7 +17,7 @@ Item {
     property string rightText: ""
     property string placeholderText: ""
     property int leftWidth: -1
-    readonly property int max_length: 40
+    property int max_length: 40
     property bool error: false
     onErrorChanged: {
         if (error) {

--- a/atomic_defi_design/Dex/Components/DexKeyChecker.qml
+++ b/atomic_defi_design/Dex/Components/DexKeyChecker.qml
@@ -13,6 +13,7 @@ ColumnLayout {
     property bool new_password: true
     property bool double_validation: false
     property string match_password
+    property int max_pw_len: General.max_std_pw_length
     property bool high_security: true
 
     function isValid() {
@@ -96,7 +97,7 @@ ColumnLayout {
             font: DexTypo.body2
             Layout.fillWidth: true
             wrapMode: DexLabel.Wrap
-            text_value: hintPrefix(hasEnoughCharacters()) + qsTr("Between %1 and %2 character(s)").arg(high_security ? 16 : 1).arg(General.max_pw_length)
+            text_value: hintPrefix(hasEnoughCharacters()) + qsTr("Between %1 and %2 character(s)").arg(high_security ? 16 : 1).arg(max_pw_len)
             color: hintColor(hasEnoughCharacters())
         }
         DexLabel {

--- a/atomic_defi_design/Dex/Components/DexKeyChecker.qml
+++ b/atomic_defi_design/Dex/Components/DexKeyChecker.qml
@@ -96,7 +96,7 @@ ColumnLayout {
             font: DexTypo.body2
             Layout.fillWidth: true
             wrapMode: DexLabel.Wrap
-            text_value: hintPrefix(hasEnoughCharacters()) + qsTr("At least %n character(s)", "", high_security ? 16 : 1)
+            text_value: hintPrefix(hasEnoughCharacters()) + qsTr("Between %1 and %2 character(s)").arg(high_security ? 16 : 1).arg(General.max_pw_length)
             color: hintColor(hasEnoughCharacters())
         }
         DexLabel {

--- a/atomic_defi_design/Dex/Components/PasswordField.qml
+++ b/atomic_defi_design/Dex/Components/PasswordField.qml
@@ -92,7 +92,7 @@ ColumnLayout {
         }
         DefaultText {
             font.pixelSize: Style.textSizeSmall3
-            text_value: hintPrefix(hasEnoughCharacters()) + qsTr("At least %n character(s)", "", high_security ? 16 : 1)
+            text_value: hintPrefix(hasEnoughCharacters()) + qsTr("Between %1 and %2 character(s)").arg(high_security ? 16 : 1).arg(General.max_pw_length)
             color: hintColor(hasEnoughCharacters())
         }
         DefaultText {

--- a/atomic_defi_design/Dex/Components/PasswordField.qml
+++ b/atomic_defi_design/Dex/Components/PasswordField.qml
@@ -7,6 +7,7 @@ import App 1.0
 ColumnLayout {
     property alias title: pw.title
     property alias field: pw.field
+    property int max_pw_len: General.max_std_pw_length
     property bool hide_hint: false
     property bool new_password: true
     property string match_password
@@ -58,6 +59,7 @@ ColumnLayout {
         title: qsTr("Password")
         field.placeholderText: qsTr("Enter your wallet password")
         field.validator: RegExpValidator { regExp: General.reg_pass_input }
+        max_length: max_pw_len
     }
 
     ColumnLayout {
@@ -92,7 +94,7 @@ ColumnLayout {
         }
         DefaultText {
             font.pixelSize: Style.textSizeSmall3
-            text_value: hintPrefix(hasEnoughCharacters()) + qsTr("Between %1 and %2 character(s)").arg(high_security ? 16 : 1).arg(General.max_pw_length)
+            text_value: hintPrefix(hasEnoughCharacters()) + qsTr("Between %1 and %2 character(s)").arg(high_security ? 16 : 1).arg(max_pw_len)
             color: hintColor(hasEnoughCharacters())
         }
         DefaultText {

--- a/atomic_defi_design/Dex/Components/PopupManager.qml
+++ b/atomic_defi_design/Dex/Components/PopupManager.qml
@@ -4,6 +4,7 @@ import Qaterial 1.0 as Qaterial
 import QtQuick.Layouts 1.12
 import App 1.0
 import Dex.Themes 1.0 as Dex
+import "../Constants"
 
 Popup
 {
@@ -161,6 +162,7 @@ Popup
                         placeholderText: dialog.placeholderText
                         field.placeholderText: ""
                         field.forceFocus: forceFocus
+                        max_length: dialog.isPassword ? General.max_pw_length : 40
                         field.rightPadding: dialog.isPassword ? 55 : 20
                         field.leftPadding: dialog.isPassword ? 70 : 20
                         field.echoMode: dialog.isPassword ? TextField.Password : TextField.Normal

--- a/atomic_defi_design/Dex/Components/PopupManager.qml
+++ b/atomic_defi_design/Dex/Components/PopupManager.qml
@@ -162,7 +162,7 @@ Popup
                         placeholderText: dialog.placeholderText
                         field.placeholderText: ""
                         field.forceFocus: forceFocus
-                        max_length: dialog.isPassword ? General.max_pw_length : 40
+                        max_length: dialog.isPassword ? General.max_std_pw_length : 40
                         field.rightPadding: dialog.isPassword ? 55 : 20
                         field.leftPadding: dialog.isPassword ? 70 : 20
                         field.echoMode: dialog.isPassword ? TextField.Password : TextField.Normal

--- a/atomic_defi_design/Dex/Components/TextFieldWithTitle.qml
+++ b/atomic_defi_design/Dex/Components/TextFieldWithTitle.qml
@@ -19,6 +19,8 @@ ColumnLayout
 
     property alias title: title_text.text
     property alias field: input_field
+    property alias max_length: input_field.maximumLength
+
     property alias hide_button: hide_button
     property alias hide_button_area: hide_button.mouseArea
 

--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -8,6 +8,7 @@ QtObject {
     readonly property int height: 800
     readonly property int minimumWidth: 1280
     readonly property int minimumHeight: 800
+    readonly property int max_pw_length: 256
     readonly property double delta_time: 1000/60
 
     readonly property string os_file_prefix: Qt.platform.os == "windows" ? "file:///" : "file://"

--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -8,7 +8,9 @@ QtObject {
     readonly property int height: 800
     readonly property int minimumWidth: 1280
     readonly property int minimumHeight: 800
-    readonly property int max_pw_length: 256
+    readonly property int max_camo_pw_length: 256
+    readonly property int max_std_pw_length: 256
+    readonly property int max_pw_length: max_std_pw_length + max_camo_pw_length
     readonly property double delta_time: 1000/60
 
     readonly property string os_file_prefix: Qt.platform.os == "windows" ? "file:///" : "file://"
@@ -20,7 +22,7 @@ QtObject {
 
     function coinIcon(ticker)
     {
-        if (ticker === "" || ticker === "All" || ticker===undefined )
+        if (ticker === "" || ticker === "All" || ticker===undefined)
         {
             return ""
         }

--- a/atomic_defi_design/Dex/Screens/Startup/ImportWallet.qml
+++ b/atomic_defi_design/Dex/Screens/Startup/ImportWallet.qml
@@ -182,6 +182,7 @@ SetupPage
                 {
                     id: _seedField
                     Layout.fillWidth: true
+                    max_length: General.max_pw_length
                     Layout.preferredHeight: 50
                     leftIcon: Qaterial.Icons.fileKey
                     field.font: DexTypo.body2

--- a/atomic_defi_design/Dex/Screens/Startup/Login.qml
+++ b/atomic_defi_design/Dex/Screens/Startup/Login.qml
@@ -64,6 +64,7 @@ SetupPage
         {
             id: _inputPassword
             Layout.alignment: Qt.AlignHCenter
+            max_length: General.max_pw_length
             height: 50
             width: 300
             background.color: Dex.CurrentTheme.floatingBackgroundColor
@@ -113,6 +114,7 @@ SetupPage
         {
             Layout.alignment: Qt.AlignHCenter
             id: _keyChecker
+            max_pw_len: General.max_pw_length
             field: _inputPassword.field
             visible: false
         }


### PR DESCRIPTION
closes https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/2054
To test:
- go thru wallet creation processes to confirm new length req message is shown.
- try to input a 256 char password into every password input field in the app, then click eyeball icon to confirm input not cut shorter
- confirm creating camouflage password still allows a single char. 