### PR TITLE
Set wallet only coins as constant

### DIFF
--- a/src/core/atomicdex/config/coins.cfg.cpp
+++ b/src/core/atomicdex/config/coins.cfg.cpp
@@ -117,6 +117,11 @@ namespace
 
 namespace atomic_dex
 {
+    bool is_wallet_only(std::string ticker)
+    {
+        return std::any_of(g_wallet_only_coins.begin(), g_wallet_only_coins.end(), [ticker](std::string x) { return ticker == x; });
+    }
+
     void
     from_json(const nlohmann::json& j, coin_config& cfg)
     {
@@ -135,7 +140,7 @@ namespace atomic_dex
         cfg.is_claimable         = j.count("is_claimable") > 0;
         cfg.is_custom_coin       = j.contains("is_custom_coin") ? j.at("is_custom_coin").get<bool>() : false;
         cfg.is_testnet           = j.contains("is_testnet") ? j.at("is_testnet").get<bool>() : false;
-        cfg.wallet_only          = j.contains("wallet_only") ? j.at("wallet_only").get<bool>() : false;
+        cfg.wallet_only          = is_wallet_only(cfg.ticker) ? is_wallet_only(cfg.ticker) : j.contains("wallet_only") ? j.at("wallet_only").get<bool>() : false;
 
         if (j.contains("other_types"))
         {

--- a/src/core/atomicdex/config/coins.cfg.hpp
+++ b/src/core/atomicdex/config/coins.cfg.hpp
@@ -25,6 +25,7 @@
 #include "atomicdex/api/mm2/utxo.merge.params.hpp"
 #include "atomicdex/config/electrum.cfg.hpp"
 #include "atomicdex/constants/qt.coins.enums.hpp"
+#include "atomicdex/constants/dex.constants.hpp"
 
 namespace atomic_dex
 {
@@ -75,4 +76,5 @@ namespace atomic_dex
     void from_json(const nlohmann::json& j, coin_config& cfg);
 
     void print_coins(std::vector<coin_config> coins);
+    bool is_wallet_only(std::string ticker);
 } // namespace atomic_dex

--- a/src/core/atomicdex/constants/dex.constants.hpp
+++ b/src/core/atomicdex/constants/dex.constants.hpp
@@ -26,7 +26,6 @@ namespace atomic_dex
         "REVS",
         "SUPERNET",
         "XPM",
-        "XVC",
         "ATOM"
     };
 }

--- a/src/core/atomicdex/constants/dex.constants.hpp
+++ b/src/core/atomicdex/constants/dex.constants.hpp
@@ -8,4 +8,25 @@ namespace atomic_dex
     inline const std::string g_primary_dex_coin{DEX_PRIMARY_COIN};
     inline const std::string g_second_primary_dex_coin{DEX_SECOND_PRIMARY_COIN};
     inline const std::vector<std::string> g_default_coins{g_primary_dex_coin, g_second_primary_dex_coin};
+    inline const std::vector<std::string> g_wallet_only_coins{
+        "ARRR-BEP20",
+        "RBTC",
+        "NVC",
+        "PAXG-ERC20",
+        "USDT-ERC20",
+        "BET",
+        "BOTS",
+        "CRYPTO",
+        "DEX",
+        "HODL",
+        "JUMBLR",
+        "MGW",
+        "MSHARK",
+        "PANGEA",
+        "REVS",
+        "SUPERNET",
+        "XPM",
+        "XVC",
+        "ATOM"
+    };
 }


### PR DESCRIPTION
To test:
- Launch app, go to coin activation menu
- Confirm coins below have "wallet only" tag
- Confirm coins below do not allow trading (see image below)
- Confirm coins below do not appear in dex coin selection combobox
```
        "ARRR-BEP20",
        "RBTC",
        "NVC",
        "PAXG-ERC20",
        "USDT-ERC20",
        "BET",
        "BOTS",
        "CRYPTO",
        "DEX",
        "HODL",
        "JUMBLR",
        "MGW",
        "MSHARK",
        "PANGEA",
        "REVS",
        "SUPERNET",
        "XPM",
        "ATOM"
```
![image](https://user-images.githubusercontent.com/35845239/201161366-cdac9251-ad44-47e5-93f9-323b7f6d417d.png)
