### PR TITLE
ensure all protocols activation state persists after logout

### DIFF
--- a/src/core/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.cpp
@@ -506,9 +506,6 @@ namespace atomic_dex
         }
         coins.erase(std::unique(coins.begin(), coins.end(), [](auto left, auto right) { return left.ticker == right.ticker; }), coins.end()); // Remove duplicates
         enable_coins(coins);
-        // This updates coins as active which might not be if activation failed.
-        // update_coin_status(this->m_current_wallet_name, tickers, true, m_coins_informations, m_coin_cfg_mutex);
-
     }
 
     void mm2_service::enable_coins(const t_coins& coins)
@@ -625,7 +622,6 @@ namespace atomic_dex
                         tickers.push_back(coin.ticker);
                         fetch_single_balance(coin);
                     }
-                    update_coin_active(tickers, true);
                     dispatcher_.trigger<coin_fully_initialized>(tickers);
 
                     std::vector<std::string> failed_tickers;
@@ -642,6 +638,7 @@ namespace atomic_dex
             {
                 SPDLOG_ERROR(error.what());
             }
+            this->m_nb_update_required += 1;
         };
         
         for (const auto& coin_config : coins)
@@ -724,7 +721,6 @@ namespace atomic_dex
                         tickers.push_back(coin.ticker);
                         fetch_single_balance(coin);
                     }
-                    update_coin_active(tickers, true);
                     dispatcher_.trigger<coin_fully_initialized>(tickers);
 
                     std::vector<std::string> failed_tickers;
@@ -741,6 +737,7 @@ namespace atomic_dex
             {
                 SPDLOG_ERROR(error.what());
             }
+            this->m_nb_update_required += 1;
         };
         
         for (const auto& coin_config : coins)
@@ -792,7 +789,6 @@ namespace atomic_dex
                 {
                     SPDLOG_ERROR("{} {}: ", rpc.request.ticker, rpc.error->error_type);
                     fetch_single_balance(get_coin_info(rpc.request.ticker));
-                    update_coin_active({rpc.request.ticker}, true);
                     m_coins_informations[rpc.request.ticker].currently_enabled = true;
                     dispatcher_.trigger<coin_fully_initialized>(coin_fully_initialized{.tickers = {rpc.request.ticker}});
                     if constexpr (std::is_same_v<RpcRequest, mm2::enable_bch_with_tokens_rpc>)
@@ -801,7 +797,6 @@ namespace atomic_dex
                         {
                             SPDLOG_ERROR("{} {}: ", slp_coin_info.ticker, rpc.error->error_type);
                             fetch_single_balance(get_coin_info(slp_coin_info.ticker));
-                            update_coin_active({slp_coin_info.ticker}, true);
                             m_coins_informations[slp_coin_info.ticker].currently_enabled = true;
                             dispatcher_.trigger<coin_fully_initialized>(coin_fully_initialized{.tickers = {slp_coin_info.ticker}});
                         }
@@ -833,6 +828,7 @@ namespace atomic_dex
                 }
                 process_balance_answer(rpc);
             }
+            this->m_nb_update_required += 1;
         };
 
         if (!has_coin(bch_ticker))
@@ -878,6 +874,7 @@ namespace atomic_dex
             m_mm2_client.process_rpc_async<mm2::enable_bch_with_tokens_rpc>(rpc.request, callback);
         }
     }
+
     
     void mm2_service::enable_slp_testnet_coin(coin_config coin_config)
     {
@@ -895,7 +892,6 @@ namespace atomic_dex
                 {
                     SPDLOG_ERROR("{} {}: ", rpc.request.ticker, rpc.error->error_type);
                     fetch_single_balance(get_coin_info(rpc.request.ticker));
-                    update_coin_active({rpc.request.ticker}, true);
                     m_coins_informations[rpc.request.ticker].currently_enabled = true;
                     dispatcher_.trigger<coin_fully_initialized>(coin_fully_initialized{.tickers = {rpc.request.ticker}});
                     if constexpr (std::is_same_v<RpcRequest, mm2::enable_bch_with_tokens_rpc>)
@@ -904,7 +900,6 @@ namespace atomic_dex
                         {
                             SPDLOG_ERROR("{} {}: ", slp_coin_info.ticker, rpc.error->error_type);
                             fetch_single_balance(get_coin_info(slp_coin_info.ticker));
-                            update_coin_active({slp_coin_info.ticker}, true);
                             m_coins_informations[slp_coin_info.ticker].currently_enabled = true;
                             dispatcher_.trigger<coin_fully_initialized>(coin_fully_initialized{.tickers = {slp_coin_info.ticker}});
                         }
@@ -936,6 +931,7 @@ namespace atomic_dex
                 }
                 process_balance_answer(rpc);
             }
+            this->m_nb_update_required += 1;
         };
         
         if (!has_coin(bch_ticker))
@@ -1380,11 +1376,6 @@ namespace atomic_dex
                                                         this->dispatcher_.trigger<enabling_z_coin_status>(tickers[idx], event);
                                                         this->dispatcher_.trigger<enabling_coin_failed>(tickers[idx], z_error[0].dump(4));
                                                         to_remove.emplace(tickers[idx]);
-
-                                                        if (error.find("already initialized") != std::string::npos)
-                                                        {
-                                                            update_coin_status(this->m_current_wallet_name, tickers, true, m_coins_informations, m_coin_cfg_mutex);
-                                                        }
                                                     }
                                                     else if (z_nb_try == 1000)
                                                     {
@@ -1427,7 +1418,7 @@ namespace atomic_dex
                                     {
                                         fetch_single_balance(get_coin_info(tickers[0]));
                                     }
-                                    // batch_balance_and_tx(false, tickers, true);
+                                    this->m_nb_update_required += 1;
                                 }
                             }
                         }
@@ -1445,6 +1436,7 @@ namespace atomic_dex
                         update_coin_status(this->m_current_wallet_name, tickers, false, m_coins_informations, m_coin_cfg_mutex);
                     });
             dispatcher_.trigger<zhtlc_leave_enabling>();
+            this->m_nb_update_required += 1;
         };
 
         for (auto&& coin: coins)


### PR DESCRIPTION
I noticed SLP tokens were not active on login. This PR makes sure they are marked in user coins file correctly to ensure this happens. Rather than setting `active` to `true` within the activation functions, this moves it to the update loop for coins returned by `get enabled coins`. This de-duplication might also potentially help with the issues mentioned in https://github.com/KomodoPlatform/atomicDEX-Desktop/pull/2060

To test:
- for each protocol (can group EVMs into one), make sure that whatever you have enabled on logging out it auto activated when you log back in. 

