### PR TITLE
Disallow disabing of parent while token active

### DIFF
--- a/atomic_defi_design/Dex/Components/CoinMenu.qml
+++ b/atomic_defi_design/Dex/Components/CoinMenu.qml
@@ -9,6 +9,7 @@ Menu {
     Universal.accent: Style.colorQtThemeAccent
     Universal.foreground: Style.colorQtThemeForeground
     Universal.background: Style.colorQtThemeBackground
+    property bool can_disable;
 
     // Ugly but required hack for automatic menu width, otherwise long texts are being cut
     width: {
@@ -28,7 +29,7 @@ Menu {
         id: disable_action
         text: qsTr("Disable %1", "TICKER").arg(ticker)
         onTriggered: API.app.disable_coins([ticker])
-        enabled: General.canDisable(ticker)
+        enabled: can_disable
     }
 
     MenuItem {

--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -579,22 +579,35 @@ QtObject {
         return exists(v) && v !== ""
     }
 
-    function isParentCoinNeeded(ticker, type) {
-        for(const c of API.app.portfolio_pg.get_all_enabled_coins())
-            if(c.type === type && c.ticker !== ticker) return true
-
+    function isParentCoinNeeded(ticker, coin_type)
+    {
+        let enabled_coins = API.app.portfolio_pg.get_all_enabled_coins()
+        for (const coin of enabled_coins)
+        {
+            let c_info = API.app.portfolio_pg.global_cfg_mdl.get_coin_info(coin)
+            if(c_info.type === coin_type && c_info.ticker !== ticker) return true
+        }
         return false
     }
 
     property Timer prevent_coin_disabling: Timer { interval: 5000 }
 
     function canDisable(ticker) {
-        if (prevent_coin_disabling.running)
-            return false
-
+        if (prevent_coin_disabling.running) return false
         if (ticker === atomic_app_primary_coin || ticker === atomic_app_secondary_coin) return false
         if (ticker === "ETH") return !General.isParentCoinNeeded("ETH", "ERC-20")
+        if (ticker === "MATIC") return !General.isParentCoinNeeded("MATIC", "Matic")
+        if (ticker === "FTM") return !General.isParentCoinNeeded("FTM", "ERC-20")
+        if (ticker === "AVAX") return !General.isParentCoinNeeded("ETH", "AVX-20")
+        if (ticker === "BNB") return !General.isParentCoinNeeded("AVAX", "BEP-20")
+        if (ticker === "ONE") return !General.isParentCoinNeeded("ONE", "HRC-20")
         if (ticker === "QTUM") return !General.isParentCoinNeeded("QTUM", "QRC-20")
+        if (ticker === "KCS") return !General.isParentCoinNeeded("KCS", "KRC-20")
+        if (ticker === "HT") return !General.isParentCoinNeeded("HT", "HecoChain")
+        if (ticker === "BCH") return !General.isParentCoinNeeded("BCH", "SLP")
+        if (ticker === "UBQ") return !General.isParentCoinNeeded("UBQ", "Ubiq")
+        if (ticker === "MOVR") return !General.isParentCoinNeeded("MOVR", "Moonriver")
+        if (ticker === "GLMR") return !General.isParentCoinNeeded("GLMR", "Moonbeam")
         if (General.isZhtlc(ticker))
         {
             let progress = General.zhtlcActivationProgress(API.app.wallet_pg.ticker_infos.activation_status, ticker)

--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -600,9 +600,9 @@ QtObject {
         if (ticker === atomic_app_primary_coin || ticker === atomic_app_secondary_coin) return false
         if (ticker === "ETH") return !General.isParentCoinNeeded("ETH", "ERC-20")
         if (ticker === "MATIC") return !General.isParentCoinNeeded("MATIC", "Matic")
-        if (ticker === "FTM") return !General.isParentCoinNeeded("FTM", "ERC-20")
-        if (ticker === "AVAX") return !General.isParentCoinNeeded("ETH", "AVX-20")
-        if (ticker === "BNB") return !General.isParentCoinNeeded("AVAX", "BEP-20")
+        if (ticker === "FTM") return !General.isParentCoinNeeded("FTM", "FTM-20")
+        if (ticker === "AVAX") return !General.isParentCoinNeeded("AVAX", "AVX-20")
+        if (ticker === "BNB") return !General.isParentCoinNeeded("BNB", "BEP-20")
         if (ticker === "ONE") return !General.isParentCoinNeeded("ONE", "HRC-20")
         if (ticker === "QTUM") return !General.isParentCoinNeeded("QTUM", "QRC-20")
         if (ticker === "KCS") return !General.isParentCoinNeeded("KCS", "KRC-20")

--- a/atomic_defi_design/Dex/Portfolio/AssetsList.qml
+++ b/atomic_defi_design/Dex/Portfolio/AssetsList.qml
@@ -304,7 +304,10 @@ Dex.DexListView
                 if (!can_change_ticker)
                     return
                 if (mouse.button === Qt.RightButton)
+                {
+                    contextMenu.can_disable = Dex.General.canDisable(ticker)
                     contextMenu.popup()
+                }
                 else
                 {
                     api_wallet_page.ticker = ticker
@@ -314,10 +317,10 @@ Dex.DexListView
 
             onPressAndHold:
             {
-                if (!can_change_ticker)
-                    return
+                if (!can_change_ticker) return
 
                 if (mouse.source === Qt.MouseEventNotSynthesized)
+                    contextMenu.can_disable = Dex.General.canDisable(ticker)
                     contextMenu.popup()
             }
         }

--- a/atomic_defi_design/Dex/Wallet/SidebarItemDelegate.qml
+++ b/atomic_defi_design/Dex/Wallet/SidebarItemDelegate.qml
@@ -29,8 +29,15 @@ GradientRectangle
         acceptedButtons: Qt.LeftButton | Qt.RightButton
         onClicked:
         {
-            if (mouse.button === Qt.RightButton) context_menu.popup()
-            else api_wallet_page.ticker = ticker
+            if (mouse.button === Qt.RightButton)
+            {
+                context_menu.can_disable = General.canDisable(ticker)
+                context_menu.popup()
+            }
+            else
+            {
+                api_wallet_page.ticker = ticker
+            }
         }
         onPressAndHold: if (mouse.source === Qt.MouseEventNotSynthesized) context_menu.popup()
     }


### PR DESCRIPTION
To Test:
- Activate a token for every EVM protocol.
- Ensure parent coin activates alongside it
- Try to disable parent coin in wallet and portfolio page while token is enabled. It should be greyed out.
- Disable all the tokens for the EMV protocol but keep parent coin enabled.
- Try to disable parent coin in wallet and portfolio page while no token is enabled. It should possible.