### PR TITLE
avoid duplication of portfolio init list

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -234,6 +234,7 @@ namespace atomic_dex
             while (not m_portfolio_queue.empty())
             {
                 const char* ticker_cstr = nullptr;
+                bool add_to_init(true);
                 m_portfolio_queue.pop(ticker_cstr);
                 std::string ticker(ticker_cstr);
                 if (ticker == g_primary_dex_coin)
@@ -244,7 +245,17 @@ namespace atomic_dex
                 {
                     this->m_secondary_coin_fully_enabled = true;
                 }
-                to_init.push_back(ticker);
+                //! TODO: figure out why sometimes ZHTLC coins end up in here twice. When they do, without this check it crashes.
+                if (std::find(to_init.begin(), to_init.end(), ticker) != to_init.end()) {
+                    SPDLOG_DEBUG("Ticker {} is already in vector", ticker);
+                    add_to_init = false;
+                }
+                else {
+                    SPDLOG_DEBUG("Ticker {} is not already in vector", ticker);
+                }
+                if (add_to_init) {
+                    to_init.push_back(ticker);
+                }
                 std::free((void*)ticker_cstr);
             }
 


### PR DESCRIPTION
Cherry picked this from https://github.com/KomodoPlatform/atomicDEX-Desktop/pull/2059 which solves a potential crash causing issue. 
To test:
- launch app, and enable ZHTLC coins from scratch (delete local cache in mm2/pubkey/DB folder).
- log out, log in to same wallet and disable / enable zhtlc coins again with recently sync'd cache