### PR TITLE
tweak custom fees display

### DIFF
--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -351,6 +351,19 @@ QtObject {
         return obj
     }
 
+    function getCustomFeeType(ticker_infos)
+    {
+        if (["SLP", "ZHTLC", "Moonbeam", "QRC-20"].includes(ticker_infos.type)) return false
+        if (!General.isSpecialToken(ticker_infos) && !General.isParentCoin(ticker_infos.ticker) ||  ["KMD"].includes(ticker_infos.ticker))
+        {
+            return "UTXO"
+        }
+        else
+        {
+            return "Gas"
+        }
+    }
+
     function getFeesDetail(fees) {
         return [
             {"label": qsTr("<b>Taker tx fee:</b> "), "fee": fees.base_transaction_fees, "ticker": fees.base_transaction_fees_ticker},

--- a/atomic_defi_design/Dex/Wallet/SendModal.qml
+++ b/atomic_defi_design/Dex/Wallet/SendModal.qml
@@ -562,6 +562,7 @@ MultipageModal
 
         ColumnLayout
         {
+            visible: General.getCustomFeeType(current_ticker_infos)
             Layout.preferredWidth: 380
             Layout.alignment: Qt.AlignHCenter
             Layout.topMargin: 32
@@ -626,7 +627,7 @@ MultipageModal
             // Normal coins, Custom fees input
             AmountField
             {
-                visible: !General.isSpecialToken(current_ticker_infos) && !General.isParentCoin(api_wallet_page.ticker) || api_wallet_page.ticker == "KMD"
+                visible: General.getCustomFeeType(current_ticker_infos) == "UTXO"
 
                 id: input_custom_fees
 
@@ -642,7 +643,7 @@ MultipageModal
             // Token coins
             ColumnLayout
             {
-                visible: (General.isSpecialToken(current_ticker_infos) || General.isParentCoin(api_wallet_page.ticker)) && api_wallet_page.ticker != "KMD"
+                visible: General.getCustomFeeType(current_ticker_infos) == "Gas"
 
                 Layout.alignment: Qt.AlignHCenter
 


### PR DESCRIPTION
- Added function for custom fee type
- Hides custom fees for GLMR / SLP / ZHTLC / QTUM until related issues are resolved or functionality exists (see https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/2092)

To Test:
- Confirm custom fees toggle / inputs not visible for GLMR / SLP / ZHTLC / QRC20 coins
- Confirm custom fees toggle / gas inputs visible for other EVM coins
- Confirm custom fees toggle / utxo inputs visible for UTXO coins