### PR TITLE
restore best order amount values

### DIFF
--- a/atomic_defi_design/Dex/Exchange/Trade/OrderBook/ListDelegate.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/OrderBook/ListDelegate.qml
@@ -109,9 +109,8 @@ Item
             {
                 orderbook_list.currentIndex = index
 
-                selectOrder(isAsk, coin, price, quantity, price_denom,
-                            price_numer, quantity_denom, quantity_numer,
-                            min_volume, base_min_volume, base_max_volume,
+                selectOrder(isAsk, coin, price, price_denom,
+                            price_numer, min_volume, base_min_volume, base_max_volume,
                             rel_min_volume, rel_max_volume, base_max_volume_denom,
                             base_max_volume_numer, uuid)
 
@@ -189,7 +188,7 @@ Item
             {
                 anchors.verticalCenter: parent.verticalCenter
                 width: parent.width * 0.37
-                text: { new BigNumber(quantity).toFixed(6) }
+                text: { new BigNumber(rel_max_volume).toFixed(6) }
                 font.family: DexTypo.fontFamily
                 font.pixelSize: 12
                 horizontalAlignment: Text.AlignRight

--- a/atomic_defi_design/Dex/Exchange/Trade/ProView.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/ProView.qml
@@ -46,18 +46,15 @@ RowLayout
     property alias bestOrders: bestOrders
     property alias placeOrderForm: placeOrderForm
 
-    function selectOrder(is_asks, coin, price, quantity, price_denom, price_numer, quantity_denom, quantity_numer, min_volume, base_min_volume, base_max_volume, rel_min_volume, rel_max_volume, base_max_volume_denom, base_max_volume_numer, uuid)
+    function selectOrder(is_asks, coin, price, price_denom, price_numer, min_volume, base_min_volume, base_max_volume, rel_min_volume, rel_max_volume, base_max_volume_denom, base_max_volume_numer, uuid)
     {
         setMarketMode(!is_asks ? MarketMode.Sell : MarketMode.Buy)
 
         API.app.trading_pg.preffered_order = {
             "coin": coin,
             "price": price,
-            "quantity": quantity,
             "price_denom": price_denom,
             "price_numer": price_numer,
-            "quantity_denom": quantity_denom,
-            "quantity_numer": quantity_numer,
             "min_volume": min_volume,
             "base_min_volume": base_min_volume,
             "base_max_volume": base_max_volume,

--- a/atomic_defi_design/Dex/Exchange/Trade/SimpleView/SubBestOrder.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/SimpleView/SubBestOrder.qml
@@ -183,7 +183,7 @@ DexListView
             {
                 Layout.preferredWidth: _quantityColumnSize
                 horizontalAlignment: Text.AlignRight
-                text_value: parseFloat(General.formatDouble(quantity, General.amountPrecision, true)).toFixed(8)
+                text_value: parseFloat(General.formatDouble(rel_max_volume, General.amountPrecision, true)).toFixed(8)
                 font.pixelSize: 14
             }
 

--- a/src/core/atomicdex/api/mm2/orderbook.order.contents.cpp
+++ b/src/core/atomicdex/api/mm2/orderbook.order.contents.cpp
@@ -75,7 +75,6 @@ namespace atomic_dex::mm2
         ss << "coin: " << coin << " ";
         ss << "address: " << address << " ";
         ss << "price: " << price << " ";
-        ss << "max_volume: " << maxvolume << " ";
         ss << "depth_percent: " << depth_percent << " ";
         ss << "base_max_volume: " << base_max_volume << " ";
         ss << "rel_max_volume: " << rel_max_volume << " ";

--- a/src/core/atomicdex/api/mm2/orderbook.order.contents.hpp
+++ b/src/core/atomicdex/api/mm2/orderbook.order.contents.hpp
@@ -33,7 +33,7 @@ namespace atomic_dex::mm2
         std::string                min_volume;
         std::string                min_volume_fraction_numer;
         std::string                min_volume_fraction_denom;
-        std::string                maxvolume;
+        std::string                max_volume;
         std::string                max_volume_fraction_numer;
         std::string                max_volume_fraction_denom;
         std::string                base_min_volume;

--- a/src/core/atomicdex/api/mm2/rpc.orderbook.cpp
+++ b/src/core/atomicdex/api/mm2/rpc.orderbook.cpp
@@ -45,7 +45,7 @@ namespace atomic_dex::mm2
             cur_asks.min_volume                 = cur_asks.base_min_volume;
             cur_asks.min_volume_fraction_numer  = cur_asks.base_min_volume_numer;
             cur_asks.min_volume_fraction_denom  = cur_asks.base_min_volume_denom;
-            cur_asks.maxvolume                  = cur_asks.base_max_volume;
+            cur_asks.max_volume                 = cur_asks.base_max_volume;
             cur_asks.max_volume_fraction_numer  = cur_asks.base_max_volume_numer;
             cur_asks.max_volume_fraction_denom  = cur_asks.base_max_volume_denom;
 
@@ -54,10 +54,10 @@ namespace atomic_dex::mm2
                 boost::trim_right_if(cur_asks.price, boost::is_any_of("0"));
                 cur_asks.price = cur_asks.price;
             }
-            cur_asks.maxvolume = atomic_dex::utils::adjust_precision(cur_asks.maxvolume);
-            t_float_50 total_f                  = safe_float(cur_asks.price) * safe_float(cur_asks.maxvolume);
+            cur_asks.max_volume = atomic_dex::utils::adjust_precision(cur_asks.max_volume);
+            t_float_50 total_f                  = safe_float(cur_asks.price) * safe_float(cur_asks.max_volume);
             cur_asks.total                      = atomic_dex::utils::adjust_precision(total_f.str());
-            result_asks_f                       = result_asks_f + safe_float(cur_asks.maxvolume);
+            result_asks_f                       = result_asks_f + safe_float(cur_asks.max_volume);
         }
         answer.asks_total_volume = result_asks_f.str();
 
@@ -67,33 +67,33 @@ namespace atomic_dex::mm2
             cur_bids.min_volume                 = cur_bids.base_min_volume;
             cur_bids.min_volume_fraction_numer  = cur_bids.base_min_volume_numer;
             cur_bids.min_volume_fraction_denom  = cur_bids.base_min_volume_denom;
-            cur_bids.maxvolume                  = cur_bids.base_max_volume;
+            cur_bids.max_volume                 = cur_bids.base_max_volume;
             cur_bids.max_volume_fraction_numer  = cur_bids.base_max_volume_numer;
             cur_bids.max_volume_fraction_denom  = cur_bids.base_max_volume_denom;
-            cur_bids.total                      = cur_bids.maxvolume;
+            cur_bids.total                      = cur_bids.max_volume;
 
             if (cur_bids.price.find('.') != std::string::npos)
             {
                 boost::trim_right_if(cur_bids.price, boost::is_any_of("0"));
                 cur_bids.price = cur_bids.price;
             }
-            cur_bids.maxvolume = atomic_dex::utils::adjust_precision(cur_bids.maxvolume);
-            t_float_50 total_f                  = safe_float(cur_bids.price) * safe_float(cur_bids.maxvolume);
+            cur_bids.max_volume = atomic_dex::utils::adjust_precision(cur_bids.max_volume);
+            t_float_50 total_f                  = safe_float(cur_bids.price) * safe_float(cur_bids.max_volume);
             cur_bids.total                      = atomic_dex::utils::adjust_precision(total_f.str());
-            result_bids_f                       = result_bids_f + safe_float(cur_bids.maxvolume);
+            result_bids_f                       = result_bids_f + safe_float(cur_bids.max_volume);
         }
         answer.bids_total_volume = result_bids_f.str();
 
         for (auto&& cur_asks: answer.asks)
         {
-            t_float_50 percent_f   = safe_float(cur_asks.maxvolume) / result_asks_f;
+            t_float_50 percent_f   = safe_float(cur_asks.max_volume) / result_asks_f;
             cur_asks.depth_percent = atomic_dex::utils::adjust_precision(percent_f.str());
             // SPDLOG_INFO("cur_asks: {}", cur_asks.to_string());
         }
 
         for (auto&& cur_bids: answer.bids)
         {
-            t_float_50 percent_f   = safe_float(cur_bids.maxvolume) / result_bids_f;
+            t_float_50 percent_f   = safe_float(cur_bids.max_volume) / result_bids_f;
             cur_bids.depth_percent = atomic_dex::utils::adjust_precision(percent_f.str());
             // SPDLOG_INFO("cur_bids: {}", cur_bids.to_string());
         }

--- a/src/core/atomicdex/models/qt.orderbook.model.cpp
+++ b/src/core/atomicdex/models/qt.orderbook.model.cpp
@@ -104,8 +104,6 @@ namespace atomic_dex
             return QString::fromStdString(m_model_data.at(index.row()).price_fraction_denom);
         case PriceNumerRole:
             return QString::fromStdString(m_model_data.at(index.row()).price_fraction_numer);
-        case QuantityRole:
-            return QString::fromStdString(m_model_data.at(index.row()).maxvolume);
         case TotalRole:
             return QString::fromStdString(m_model_data.at(index.row()).total);
         case UUIDRole:
@@ -114,10 +112,6 @@ namespace atomic_dex
             return m_model_data.at(index.row()).is_mine;
         case PercentDepthRole:
             return QString::fromStdString(m_model_data.at(index.row()).depth_percent);
-        case QuantityDenomRole:
-            return QString::fromStdString(m_model_data.at(index.row()).max_volume_fraction_denom);
-        case QuantityNumerRole:
-            return QString::fromStdString(m_model_data.at(index.row()).max_volume_fraction_numer);
         case BaseMinVolumeRole:
             return QString::fromStdString(m_model_data.at(index.row()).base_min_volume);
         case BaseMinVolumeDenomRole:
@@ -269,9 +263,6 @@ namespace atomic_dex
         case IsMineRole:
             order.is_mine = value.toBool();
             break;
-        case QuantityRole:
-            order.maxvolume = value.toString().toStdString();
-            break;
         case TotalRole:
             order.total = value.toString().toStdString();
             break;
@@ -280,12 +271,6 @@ namespace atomic_dex
             break;
         case PercentDepthRole:
             order.depth_percent = value.toString().toStdString();
-            break;
-        case QuantityDenomRole:
-            order.max_volume_fraction_denom = value.toString().toStdString();
-            break;
-        case QuantityNumerRole:
-            order.max_volume_fraction_numer = value.toString().toStdString();
             break;
         case CoinRole:
             order.coin = value.toString().toStdString();
@@ -352,14 +337,11 @@ namespace atomic_dex
         return {
             {PriceRole, "price"},
             {CoinRole, "coin"},
-            {QuantityRole, "quantity"},
             {TotalRole, "total"},
             {UUIDRole, "uuid"},
             {IsMineRole, "is_mine"},
             {PriceDenomRole, "price_denom"},
             {PriceNumerRole, "price_numer"},
-            {QuantityDenomRole, "quantity_denom"},
-            {QuantityNumerRole, "quantity_numer"},
             {PercentDepthRole, "depth"},
             {MinVolumeRole, "min_volume"},
             {EnoughFundsToPayMinVolume, "enough_funds_to_pay_min_volume"},
@@ -461,7 +443,6 @@ namespace atomic_dex
             update_value(OrderbookRoles::PriceNumerRole, QString::fromStdString(order.price_fraction_numer), idx, *this);
             update_value(OrderbookRoles::PriceDenomRole, QString::fromStdString(order.price_fraction_denom), idx, *this);
             update_value(OrderbookRoles::IsMineRole, order.is_mine, idx, *this);
-            update_value(OrderbookRoles::QuantityRole, QString::fromStdString(order.maxvolume), idx, *this);
             update_value(OrderbookRoles::TotalRole, QString::fromStdString(order.total), idx, *this);
             update_value(OrderbookRoles::PercentDepthRole, QString::fromStdString(order.depth_percent), idx, *this);
             update_value(OrderbookRoles::BaseMinVolumeRole, QString::fromStdString(order.base_min_volume), idx, *this);
@@ -488,7 +469,6 @@ namespace atomic_dex
                  OrderbookRoles::PriceNumerRole,
                  OrderbookRoles::PriceDenomRole,
                  OrderbookRoles::IsMineRole,
-                 OrderbookRoles::QuantityRole,
                  OrderbookRoles::TotalRole,
                  OrderbookRoles::PercentDepthRole,
                  OrderbookRoles::BaseMinVolumeRole,
@@ -651,11 +631,8 @@ namespace atomic_dex
             const bool         is_buy     = trading_pg.get_market_mode() == MarketMode::Buy;
             out["coin"]                   = QString::fromStdString(is_buy ? order.rel_coin.value() : order.coin);
             out["price"]                  = QString::fromStdString(order.price);
-            out["quantity"]               = QString::fromStdString(order.maxvolume);
             out["price_denom"]            = QString::fromStdString(order.price_fraction_denom);
             out["price_numer"]            = QString::fromStdString(order.price_fraction_numer);
-            out["quantity_denom"]         = QString::fromStdString(order.max_volume_fraction_denom);
-            out["quantity_numer"]         = QString::fromStdString(order.max_volume_fraction_numer);
             out["min_volume"]             = QString::fromStdString(order.min_volume);
             out["base_min_volume"]        = QString::fromStdString(order.base_min_volume);
             out["base_max_volume"]        = QString::fromStdString(order.base_max_volume);

--- a/src/core/atomicdex/models/qt.orderbook.model.hpp
+++ b/src/core/atomicdex/models/qt.orderbook.model.hpp
@@ -52,14 +52,11 @@ namespace atomic_dex
         {
             PriceRole = Qt::UserRole + 1, // 257
             CoinRole,
-            QuantityRole,
             TotalRole,
             UUIDRole,
             IsMineRole,
             PriceDenomRole,
             PriceNumerRole,
-            QuantityDenomRole,
-            QuantityNumerRole,
             PercentDepthRole,
             MinVolumeRole,
             EnoughFundsToPayMinVolume,

--- a/src/core/atomicdex/models/qt.orderbook.proxy.model.cpp
+++ b/src/core/atomicdex/models/qt.orderbook.proxy.model.cpp
@@ -48,8 +48,6 @@ namespace atomic_dex
         {
         case orderbook_model::PriceRole:
             return safe_float(left_data.toString().toStdString()) < safe_float(right_data.toString().toStdString());
-        case orderbook_model::QuantityRole:
-            break;
         case orderbook_model::TotalRole:
             break;
         case orderbook_model::UUIDRole:
@@ -61,10 +59,6 @@ namespace atomic_dex
         case orderbook_model::PriceNumerRole:
             break;
         case orderbook_model::PercentDepthRole:
-            break;
-        case orderbook_model::QuantityDenomRole:
-            break;
-        case orderbook_model::QuantityNumerRole:
             break;
         case orderbook_model::CoinRole:
             break;

--- a/src/core/atomicdex/pages/widgets/dex/qt.orderbook.cpp
+++ b/src/core/atomicdex/pages/widgets/dex/qt.orderbook.cpp
@@ -194,11 +194,8 @@ namespace atomic_dex
             t_order_contents   order     = m_best_orders->get_order_content(idx);
             out["coin"]                  = QString::fromStdString(is_buy ? order.rel_coin.value() : order.coin);
             out["price"]                 = QString::fromStdString(order.price);
-            out["quantity"]              = QString::fromStdString(order.maxvolume);
             out["price_denom"]           = QString::fromStdString(order.price_fraction_denom);
             out["price_numer"]           = QString::fromStdString(order.price_fraction_numer);
-            out["quantity_denom"]        = QString::fromStdString(order.max_volume_fraction_denom);
-            out["quantity_numer"]        = QString::fromStdString(order.max_volume_fraction_numer);
             out["min_volume"]            = QString::fromStdString(order.min_volume);
             out["base_min_volume"]       = QString::fromStdString(order.base_min_volume);
             out["base_max_volume"]       = QString::fromStdString(order.base_max_volume);


### PR DESCRIPTION
closes: https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/2129
To test: 
- go to dex simple view
- confirm available amounts are populated and not zero
- do a swap in simple view, and make sure values in form match confirmation and swap progress modals