### PR TITLE
update workflow to ensure using ubuntu 20.04

### DIFF
--- a/.github/workflows/atomicdex-desktop-ci.yml
+++ b/.github/workflows/atomicdex-desktop-ci.yml
@@ -38,13 +38,13 @@ jobs:
 
         include:
           - name: ubuntu-release
-            os: ubuntu-latest
+            os: ubuntu-20.04
             qt: '5.15.2'
             type: 'Release'
             host: 'linux'
 
           - name: ubuntu-debug
-            os: ubuntu-latest
+            os: ubuntu-20.04
             qt: '5.15.2'
             type: 'Debug'
             host: 'linux'


### PR DESCRIPTION
ref: https://github.blog/changelog/2022-12-01-github-actions-larger-runners-using-ubuntu-latest-label-will-now-use-ubuntu-22-04/