### PR TITLE
Make KMD right ticker & LTC left ticker

### DIFF
--- a/atomic_defi_design/Dex/Exchange/Trade/Trade.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/Trade.qml
@@ -93,13 +93,21 @@ Item
     {
         if (!General.initialized_orderbook_pair)
         {
-            General.initialized_orderbook_pair = true
-            API.app.trading_pg.set_current_orderbook(General.default_base,
+            if (API.app.trading_pg.current_trading_mode == TradingMode.Pro)
+            {
+                API.app.trading_pg.set_current_orderbook(General.default_base,
                                                      General.default_rel)
+            }
+            else
+            {
+                API.app.trading_pg.set_current_orderbook(General.default_rel,
+                                                     General.default_base)
+            }
+            General.initialized_orderbook_pair = true
         }
         setPair(true, ticker)
-        // triggers chart reload
-        app.pairChanged(base_ticker, rel_ticker)
+        // triggers chart reload (why the duplication?)
+        // app.pairChanged(base_ticker, rel_ticker)
     }
 
     function setPair(is_left_side, changed_ticker, is_swap=false) {

--- a/atomic_defi_design/Dex/Screens/Dashboard.qml
+++ b/atomic_defi_design/Dex/Screens/Dashboard.qml
@@ -82,7 +82,20 @@ Item
 
     Layout.fillWidth: true
 
-    onCurrentPageChanged: sidebar.currentLineType = currentPage
+    onCurrentPageChanged: {
+        sidebar.currentLineType = currentPage
+        if (currentPage == Dashboard.PageType.DEX)
+        {
+            if (API.app.trading_pg.current_trading_mode == TradingMode.Pro)
+            {
+                API.app.trading_pg.set_pair(false, api_wallet_page.ticker)
+            }
+            else
+            {
+                API.app.trading_pg.set_pair(true, api_wallet_page.ticker)
+            }
+        }
+    }
 
     SupportPage.SupportModal { id: support_modal }
 

--- a/cmake/project.metadata.cmake
+++ b/cmake/project.metadata.cmake
@@ -10,8 +10,8 @@ set(DEX_WEBSITE "https://atomicdex.io/")
 set(DEX_SUPPORT_PAGE "https://support.komodoplatform.com/support/home")
 set(DEX_DISCORD "https://komodoplatform.com/discord")
 set(DEX_TWITTER "https://twitter.com/AtomicDEX")
-set(DEX_PRIMARY_COIN "KMD")                                                         ## Main coin of the DEX, will be enabled by default and will be the default left ticker for trading
-set(DEX_SECOND_PRIMARY_COIN "LTC")                                                  ## Second main coin of the DEX, will be enabled by default and will be the default right ticker for trading
+set(DEX_PRIMARY_COIN "LTC")                                                         ## Main coin of the DEX, will be enabled by default and will be the default left ticker for trading
+set(DEX_SECOND_PRIMARY_COIN "KMD")                                                  ## Second main coin of the DEX, will be enabled by default and will be the default right ticker for trading
 option(DISABLE_GEOBLOCKING "Enable to disable geoblocking (for dev purpose)" OFF)
 set(DEX_REPOSITORY_OWNER ${DEX_COMPANY})
 set(DEX_REPOSITORY_NAME "atomicDEX-Desktop")


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/2146

To test:
- Login and go to dex pro view. LTC should be left ticker, and KMD right ticker
- Go to wallet page for a different coin. Click on "Swap". When it takes you to Pro view, Wallet coin should be left ticker, and KMD right ticker.
- Log in fresh. Go to Simple view. KMD should be the default "From" coin.
- Go to wallet page for a different coin. Click on "Swap". When it takes you to Simple view, "From" coin should be wallet coin.
