### PR TITLE
add message when ZHTLC not yet fully activated

### DIFF
--- a/atomic_defi_design/Dex/Settings/RecoverSeedModal.qml
+++ b/atomic_defi_design/Dex/Settings/RecoverSeedModal.qml
@@ -375,7 +375,7 @@ MultipageModal
                                     DefaultText
                                     {
                                         id: publicAddress
-                                        text: model.public_address
+                                        text: model.public_address != 'Invalid Ticker' ? model.public_address : "Please wait for " + model.name + " to fully activate..."
                                         font: model.public_address.length > 70 ? DexTypo.body4 : DexTypo.body3
                                     }
                                 }


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/2156

To Test:
- login to a wallet which will not activate ARRR or ZOMBIE too fast
- Go to settings > view seed and private keys
- See message instead of private keys for the partially activated coins


Before:
![image](https://user-images.githubusercontent.com/35845239/205995094-a0437511-89f0-49f3-b681-3ecba6925f01.png)

After:
![image](https://user-images.githubusercontent.com/35845239/205995142-4cd2ef64-d526-4fcb-bc53-d2f657734ef8.png)
