### PR TITLE
restore autofocus on wallet page

### DIFF
--- a/atomic_defi_design/Dex/Wallet/Sidebar.qml
+++ b/atomic_defi_design/Dex/Wallet/Sidebar.qml
@@ -60,7 +60,7 @@ Item
                     Layout.preferredHeight: 38
 
                     textField.placeholderText: qsTr("Search")
-                    //forceFocus: true
+                    forceFocus: true
                     searchModel: portfolio_coins
                 }
 


### PR DESCRIPTION
closes https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/2081

To test:
- Login, go to wallet page. 
- Cursor should be in the search input above the sidebar coins list, and you should be able to type in that field after page loads without needing to click the mouse into it.
![image](https://user-images.githubusercontent.com/35845239/206208100-1789c791-75fd-40b5-9cf3-0f08181ff32a.png)
