### PR TITLE
force zhtlc activation the good old fashioned way

### DIFF
--- a/atomic_defi_design/Dex/Exchange/Trade/BestOrder/ListDelegate.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/BestOrder/ListDelegate.qml
@@ -122,7 +122,9 @@ Item
 
         contentItem: DexLabelUnlinked
         {
-            text_value: qsTr(" %1 is not enabled - Do you want to enable it to be able to select %2 best orders ?<br><a href='#'>Yes</a> - <a href='#no'>No</a>").arg(coin).arg(coin)
+            text_value: !General.isZhtlc(coin) ? 
+                qsTr(" %1 is not enabled - Do you want to enable it to be able to select %2 best orders ?<br><a href='#'>Yes</a> - <a href='#no'>No</a>").arg(coin).arg(coin) :
+                qsTr(" %1 is not enabled - Please enable it through the coin activation menu").arg(coin)
             wrapMode: DefaultText.Wrap
             width: 250
             onLinkActivated:

--- a/atomic_defi_design/Dex/Exchange/Trade/SimpleView/SubBestOrder.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/SimpleView/SubBestOrder.qml
@@ -222,7 +222,9 @@ DexListView
 
                 contentItem: DexLabelUnlinked
                 {
-                    text_value: qsTr(" %1 is not enabled - Do you want to enable it to be able to select %2 best orders ?<br><a href='#'>Yes</a> - <a href='#no'>No</a>").arg(coin).arg(coin)
+                    text_value: !General.isZhtlc(coin) ? 
+                        qsTr(" %1 is not enabled - Do you want to enable it to be able to select %2 best orders ?<br><a href='#'>Yes</a> - <a href='#no'>No</a>").arg(coin).arg(coin) :
+                        qsTr(" %1 is not enabled - Please enable it through the coin activation menu").arg(coin)
                     wrapMode: DexLabel.Wrap
                     width: 250
                     onLinkActivated:


### PR DESCRIPTION
Mitigates https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/2142 (can leave issue open for later)

To test:
- disable ARRR
- Go to simple view, select KMD as "From" coin
- Scroll thru "To" coin list and click on ARRR. You should see message saying to enable via coin activation menu.
- Click on a disabled non-zhtlc coin. You should be able to enable it from the pop up.
- disable ARRR
- Go to pro view, select to sell KMD, and select an order from the orderbook to make bestorders populate
- Scroll thru bestorders and click on ARRR. You should see message saying to enable via coin activation menu.
- Click on a disabled non-zhtlc coin. You should be able to enable it from the pop up.

@SirSevenG this PR does not solve the potential crash issue you posted, but will stop a user from being unable to get to where the crash might occur. A more complete fix could be implemented later, but for now this defends against the worst outcome.