### PR TITLE
limit warning text values to 8dp

### DIFF
--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -571,18 +571,15 @@ QtObject {
     }
 
     function getMinTradeAmount() {
-        /*if (API.app.trading_pg.market_mode == MarketMode.Buy) {
-            return API.app.trading_pg.orderbook.rel_min_taker_vol
-        }*/
-        return API.app.trading_pg.min_trade_vol
+        return formatDouble(API.app.trading_pg.min_trade_vol, 8, false).toString()
     }
 
     function getReversedMinTradeAmount() {
-            if (API.app.trading_pg.market_mode == MarketMode.Buy) {
-               return API.app.trading_pg.min_trade_vol
-            }
-            return API.app.trading_pg.orderbook.rel_min_taker_vol
+        if (API.app.trading_pg.market_mode == MarketMode.Buy) {
+           return getMinTradeAmount()
         }
+        return formatDouble(API.app.trading_pg.orderbook.rel_min_taker_vol, 8, false).toString()
+    }
 
     function hasEnoughFunds(sell, base, rel, price, volume) {
         if(sell) {


### PR DESCRIPTION
closes https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/2177

To test:
- simulate case where low balance error happens in pro view (you can do this by broadcasting a withdrawal in CLI using the app RPC credentials, then trying to do a swap soon after)