### PR TITLE
suppress matic balance notifications

### DIFF
--- a/src/core/atomicdex/managers/notification.manager.cpp
+++ b/src/core/atomicdex/managers/notification.manager.cpp
@@ -64,7 +64,10 @@ namespace atomic_dex
         SPDLOG_INFO(
             "balance update notification: am_i_sender: {} amount: {} ticker: {} human_date: {}", evt.am_i_sender, evt.amount.toStdString(),
             evt.ticker.toStdString(), evt.human_date.toStdString());
-        emit balanceUpdateStatus(evt.am_i_sender, evt.amount, evt.ticker, evt.human_date, evt.timestamp);
+        if (evt.ticker.toStdString() != "MATIC")
+        {
+            emit balanceUpdateStatus(evt.am_i_sender, evt.amount, evt.ticker, evt.human_date, evt.timestamp);
+        }
     }
 
     void


### PR DESCRIPTION
There is currently an issue where users will get unexpected notifications about matic balance due to inconsistent upstream data. This may be due to hitting api rate limits, though I've not been able to investigate thorougly yet.
In the meantime, we can suppress notifications related to MATIC balance changes to keep UX intact.