### PR TITLE
source coin icons before make for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,6 @@ else ()
     configure_file(${mm2_SOURCE_DIR}/mm2.exe ${CMAKE_BINARY_DIR}/bin/assets/tools/mm2/${DEX_API}.exe COPYONLY)
     configure_file(${mm2_SOURCE_DIR}/msvcp140.dll ${CMAKE_BINARY_DIR}/bin/assets/tools/mm2/msvcp140.dll COPYONLY)
     configure_file(${mm2_SOURCE_DIR}/vcruntime140.dll ${CMAKE_BINARY_DIR}/bin/assets/tools/mm2/vcruntime140.dll COPYONLY)
-    file(COPY ${jl777-coins_SOURCE_DIR}/icons/ DESTINATION ${mm2_SOURCE_DIR}/bin/atomic_defi_design/assets/images/coins/)
 endif ()
 
 add_subdirectory(vendor/antara-gaming_sdk/modules)

--- a/ci_tools_atomic_dex/ci_scripts/windows_script.ps1
+++ b/ci_tools_atomic_dex/ci_scripts/windows_script.ps1
@@ -14,10 +14,16 @@ scoop cache rm git
 scoop cache rm cmake
 scoop cache rm ninja
 scoop cache rm llvm
+
 $Env:QT_INSTALL_CMAKE_PATH = "C:\Qt\$Env:QT_VERSION\msvc2019_64"
 $Env:QT_ROOT = "C:\Qt"
+
+git clone https://github.com/KomodoPlatform/coins/ -b master
+mkdir -p atomic_defi_design\assets\images\coins
+Get-Item -Path "coins\icons\*.png" | Move-Item -Destination "atomic_defi_design\assets\images\coins"
+
 mkdir b
 cd b
-cmake --version
+
 cmake -DCMAKE_BUILD_TYPE=Release -GNinja ../
 ninja install


### PR DESCRIPTION
The way the CI runs, Linux and Mac use `./ci_tools_atomic_dex` (nim), and windows does not. Since https://github.com/KomodoPlatform/atomicDEX-Desktop/pull/2194 this has led to missing coin icons in Windows builds. 

To test:
- launch in windows and confirm coin icon images are visible (use portable from https://github.com/KomodoPlatform/atomicDEX-Desktop/actions/runs/4331602560).