### PR TITLE
don't update max_taker_vol on every orderbook update

### DIFF
--- a/src/core/atomicdex/pages/qt.trading.page.cpp
+++ b/src/core/atomicdex/pages/qt.trading.page.cpp
@@ -56,7 +56,7 @@ namespace atomic_dex
         {
             m_actions_queue.push(trading_actions::post_process_orderbook_finished);
             m_models_actions[orderbook_need_a_reset] = evt.is_a_reset;
-            determine_max_volume();
+            //determine_max_volume();
         }
     }
 } // namespace atomic_dex


### PR DESCRIPTION
the max_taker_vol call can take several seconds to process, see: https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/2196
the values usually don't change, so there is no need to do this call every 5s, on every orderbook update
the call is done anyway every time you click on an order in the orderbook (even if the already selected order is selected again), which is fine to update the values (based on new order or based on changed balance/txfee... fees don't change every 5s)