### PR TITLE
remove nomics and replace chart

### DIFF
--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -37,39 +37,14 @@ QtObject {
         }
     }
 
-
-    function getChartExcludeList(ticker)
-    {
-        let coin_info = API.app.portfolio_pg.global_cfg_mdl.get_coin_info(ticker)
-        let exclude_list = ["RICK", "MORTY", "ZOMBIE"]
-        if (ticker.search("TEST") > -1 || ticker.search("t") == 0 || coin_info.is_testnet)
-        {
-            exclude_list.push(ticker)
-        }
-        return exclude_list
-    }
-
-
     function getChartTicker(ticker)
     {
-        ticker = coinWithoutSuffix(ticker)
-        let exclude_list = getChartExcludeList(ticker)
-        let redefine_list = {}
-        if (exclude_list.includes(ticker))
-        {
-            return ""
-        }
-        if (redefine_list.hasOwnProperty(ticker))
-        {
-            return redefine_list[ticker]
-        }
-        return ticker        
+        let coin_info = API.app.portfolio_pg.global_cfg_mdl.get_coin_info(ticker)
+        return coin_info.livecoinwatch_id
     }
-
 
     function coinWithoutSuffix(ticker)
     {
-        console.log("coinWithoutSuffix: " + ticker)
         if (ticker.search("-") > -1)
         {
             return ticker.split("-")[0]
@@ -78,6 +53,12 @@ QtObject {
         {
             return ticker
         }
+    }
+
+    function is_testcoin(ticker)
+    {
+        let coin_info = API.app.portfolio_pg.global_cfg_mdl.get_coin_info(ticker)
+        return coin_info.is_testnet
     }
 
     function coinName(ticker) {

--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -37,6 +37,36 @@ QtObject {
         }
     }
 
+
+    function getChartExcludeList(ticker)
+    {
+        let coin_info = API.app.portfolio_pg.global_cfg_mdl.get_coin_info(ticker)
+        let exclude_list = ["RICK", "MORTY", "ZOMBIE"]
+        if (ticker.search("TEST") > -1 || ticker.search("t") == 0 || coin_info.is_testnet)
+        {
+            exclude_list.push(ticker)
+        }
+        return exclude_list
+    }
+
+
+    function getChartTicker(ticker)
+    {
+        ticker = coinWithoutSuffix(ticker)
+        let exclude_list = getChartExcludeList(ticker)
+        let redefine_list = {}
+        if (exclude_list.includes(ticker))
+        {
+            return ""
+        }
+        if (redefine_list.hasOwnProperty(ticker))
+        {
+            return redefine_list[ticker]
+        }
+        return ticker        
+    }
+
+
     function coinWithoutSuffix(ticker)
     {
         console.log("coinWithoutSuffix: " + ticker)

--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -115,16 +115,6 @@ QtObject {
         return progress
     }
 
-    function getNomicsId(ticker) {
-        if(ticker === "" || ticker === "All" || ticker===undefined) {
-            return ""
-        } else {
-            const nomics_id = API.app.portfolio_pg.global_cfg_mdl.get_coin_info(ticker).nomics_id
-            if (nomics_id == 'test-coin') return ""
-            return nomics_id
-        }
-    }
-
     function coinContractAddress(ticker) {
         var cfg = API.app.trading_pg.get_raw_mm2_coin_cfg(ticker)
         if (cfg.hasOwnProperty('protocol')) {

--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -37,6 +37,19 @@ QtObject {
         }
     }
 
+    function coinWithoutSuffix(ticker)
+    {
+        console.log("coinWithoutSuffix: " + ticker)
+        if (ticker.search("-") > -1)
+        {
+            return ticker.split("-")[0]
+        }
+        else
+        {
+            return ticker
+        }
+    }
+
     function coinName(ticker) {
         if(ticker === "" || ticker === "All" || ticker===undefined) {
             return ""

--- a/atomic_defi_design/Dex/Exchange/Exchange.qml
+++ b/atomic_defi_design/Dex/Exchange/Exchange.qml
@@ -9,7 +9,8 @@ import App 1.0
 Item
 {
     id: exchange
-    readonly property int layout_margin: 15
+    readonly property int layout_margin: 12
+    width: 495
 
     property int current_page: idx_exchange_trade
 

--- a/atomic_defi_design/Dex/Exchange/ProView/Chart.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/Chart.qml
@@ -46,12 +46,12 @@ Item
                 return
             }
 
-            right_ticker = General.getChartTicker(right_ticker)
-            left_ticker = General.getChartTicker(left_ticker)
-            if (right_ticker != "" && left_ticker != "")
+            let rel_ticker = General.getChartTicker(right_ticker)
+            let base_ticker = General.getChartTicker(left_ticker)
+            if (rel_ticker != "" && base_ticker != "")
             {
                 pair_supported = true
-                symbol = right_ticker+"-"+left_ticker
+                symbol = rel_ticker+"-"+base_ticker
                 if (symbol === loaded_symbol && !force)
                 {
                     webEngineViewPlaceHolder.visible = true
@@ -66,7 +66,7 @@ Item
                     }
                 </style>
                 <script defer src="https://www.livecoinwatch.com/static/lcw-widget.js"></script>
-                <div class="livecoinwatch-widget-1" lcw-coin="${right_ticker}" lcw-base="${left_ticker}" lcw-secondary="USDC" lcw-period="w" lcw-color-tx="#ffffff" lcw-color-pr="#58c7c5" lcw-color-bg="#1f2434" lcw-border-w="1" ></div>
+                <div class="livecoinwatch-widget-1" lcw-coin="${rel_ticker}" lcw-base="${base_ticker}" lcw-secondary="USDC" lcw-period="w" lcw-color-tx="#ffffff" lcw-color-pr="#58c7c5" lcw-color-bg="#1f2434" lcw-border-w="1" ></div>
                 `
             }
         }

--- a/atomic_defi_design/Dex/Exchange/ProView/Chart.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/Chart.qml
@@ -17,20 +17,28 @@ Item
     property bool pair_supported: false
     onPair_supportedChanged: if (!pair_supported) webEngineViewPlaceHolder.visible = false
 
-    function loadChart(right_ticker, left_ticker, force = false, source="nomics")
+    function loadChart(right_ticker, left_ticker, force = false, source="livecoinwatch")
     {
+
+        // <script defer src="https://www.livecoinwatch.com/static/lcw-widget.js"></script> <div class="livecoinwatch-widget-1" lcw-coin="BTC" lcw-base="USD" lcw-secondary="BTC" lcw-period="d" lcw-color-tx="#ffffff" lcw-color-pr="#58c7c5" lcw-color-bg="#1f2434" lcw-border-w="1" ></div>
+
         let chart_html = ""
         let symbol = ""
+        let widget_x = 390
+        let widget_y = 150
+        let scale_x = root.width / widget_x
+        let scale_y = root.height / widget_y
+        console.log("chart_x", widget_x)
+        console.log("chart_y", widget_y)
+        console.log("root.width", root.width)
+        console.log("root.height", root.height)
+        
 
-        if (source == "nomics")
+        if (source == "livecoinwatch")
         {
-            let right_ticker_full = General.coinName(right_ticker)
-            let right_ticker_id = General.getNomicsId(right_ticker)
-            let left_ticker_id = General.getNomicsId(left_ticker)
-
-            if (right_ticker_id != "" && left_ticker_id != "")
+            if (right_ticker != "" && left_ticker != "")
             {
-                symbol = right_ticker_id+"-"+left_ticker_id
+                symbol = right_ticker+"-"+left_ticker
 
                 pair_supported = true
                 if (symbol === loaded_symbol && !force)
@@ -38,20 +46,20 @@ Item
                     webEngineViewPlaceHolder.visible = true
                     return
                 }
-
-                loaded_symbol = symbol
-
                 chart_html = `
                 <style>
-                body { margin: 0; }
+                    body { margin: auto; }
+                    .livecoinwatch-widget-1 {
+                        transform: scale(${Math.min(scale_x, scale_y)});
+                        transform-origin: top left;
+                    }
                 </style>
-
-                <!-- Nomics Widget BEGIN -->
-                <div class="nomics-ticker-widget" data-name="${right_ticker_full}" data-base="${right_ticker_id}" data-quote="${left_ticker_id}"></div>
-                <script src="https://widget.nomics.com/embed.js"></script>
-                <!-- Nomics Widget END -->`
+                <script defer src="https://www.livecoinwatch.com/static/lcw-widget.js"></script>
+                <div class="livecoinwatch-widget-1" lcw-coin="${right_ticker}" lcw-base="${left_ticker}" lcw-secondary="USDC" lcw-period="d" lcw-color-tx="#ffffff" lcw-color-pr="#58c7c5" lcw-color-bg="#1f2434" lcw-border-w="1" ></div>
+                `
             }
         }
+        console.log(chart_html)
 
         if (chart_html == "")
         {
@@ -78,7 +86,7 @@ Item
 
             loaded_symbol = symbol
 
-            let chart_html = `
+            chart_html = `
             <style>
             body { margin: 0; }
             </style>
@@ -110,6 +118,15 @@ Item
 
     Component.onCompleted:
     {
+        try
+        {
+            loadChart(left_ticker?? atomic_app_primary_coin,
+                      right_ticker?? atomic_app_secondary_coin)
+        }
+        catch (e) { console.error(e) }
+    }
+
+    onWidthChanged: {
         try
         {
             loadChart(left_ticker?? atomic_app_primary_coin,

--- a/atomic_defi_design/Dex/Exchange/ProView/Chart.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/Chart.qml
@@ -42,6 +42,8 @@ Item
                     webEngineViewPlaceHolder.visible = true
                     return
                 }
+                right_ticker = General.coinWithoutSuffix(right_ticker)
+                left_ticker = General.coinWithoutSuffix(left_ticker)
                 chart_html = `
                 <style>
                     body { margin: auto; }

--- a/atomic_defi_design/Dex/Exchange/ProView/Chart.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/Chart.qml
@@ -20,7 +20,7 @@ Item
     function loadChart(right_ticker, left_ticker, force = false, source="livecoinwatch")
     {
 
-        // <script defer src="https://www.livecoinwatch.com/static/lcw-widget.js"></script> <div class="livecoinwatch-widget-1" lcw-coin="BTC" lcw-base="USD" lcw-secondary="BTC" lcw-period="d" lcw-color-tx="#ffffff" lcw-color-pr="#58c7c5" lcw-color-bg="#1f2434" lcw-border-w="1" ></div>
+        // <script defer src="https://www.livecoinwatch.com/static/lcw-widget.js"></script> <div class="livecoinwatch-widget-1" lcw-coin="BTC" lcw-base="USD" lcw-secondary="BTC" lcw-period="w" lcw-color-tx="#ffffff" lcw-color-pr="#58c7c5" lcw-color-bg="#1f2434" lcw-border-w="1" ></div>
 
         let chart_html = ""
         let symbol = ""
@@ -28,10 +28,6 @@ Item
         let widget_y = 150
         let scale_x = root.width / widget_x
         let scale_y = root.height / widget_y
-        console.log("chart_x", widget_x)
-        console.log("chart_y", widget_y)
-        console.log("root.width", root.width)
-        console.log("root.height", root.height)
         
 
         if (source == "livecoinwatch")
@@ -55,12 +51,10 @@ Item
                     }
                 </style>
                 <script defer src="https://www.livecoinwatch.com/static/lcw-widget.js"></script>
-                <div class="livecoinwatch-widget-1" lcw-coin="${right_ticker}" lcw-base="${left_ticker}" lcw-secondary="USDC" lcw-period="d" lcw-color-tx="#ffffff" lcw-color-pr="#58c7c5" lcw-color-bg="#1f2434" lcw-border-w="1" ></div>
+                <div class="livecoinwatch-widget-1" lcw-coin="${right_ticker}" lcw-base="${left_ticker}" lcw-secondary="USDC" lcw-period="w" lcw-color-tx="#ffffff" lcw-color-pr="#58c7c5" lcw-color-bg="#1f2434" lcw-border-w="1" ></div>
                 `
             }
         }
-        console.log(chart_html)
-
         if (chart_html == "")
         {
             const pair = atomic_qt_utilities.retrieve_main_ticker(left_ticker) + "/" + atomic_qt_utilities.retrieve_main_ticker(right_ticker)

--- a/atomic_defi_design/Dex/Exchange/ProView/Chart.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/Chart.qml
@@ -28,7 +28,6 @@ Item
         let widget_y = 150
         let scale_x = root.width / widget_x
         let scale_y = root.height / widget_y
-        
 
         if (source == "livecoinwatch")
         {
@@ -42,8 +41,13 @@ Item
                     webEngineViewPlaceHolder.visible = true
                     return
                 }
-                right_ticker = General.coinWithoutSuffix(right_ticker)
-                left_ticker = General.coinWithoutSuffix(left_ticker)
+                right_ticker = General.getChartTicker(right_ticker)
+                left_ticker = General.getChartTicker(left_ticker)
+                if (left_ticker == "" || right_ticker == "")
+                {
+                    pair_supported = false
+                    return
+                }
                 chart_html = `
                 <style>
                     body { margin: auto; }
@@ -57,6 +61,8 @@ Item
                 `
             }
         }
+        // console.log(chart_html)
+
         if (chart_html == "")
         {
             const pair = atomic_qt_utilities.retrieve_main_ticker(left_ticker) + "/" + atomic_qt_utilities.retrieve_main_ticker(right_ticker)

--- a/atomic_defi_design/Dex/Exchange/ProView/Chart.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/Chart.qml
@@ -15,6 +15,7 @@ Item
     readonly property string theme: Dex.CurrentTheme.getColorMode() === Dex.CurrentTheme.ColorMode.Dark ? "dark" : "light"
     property string loaded_symbol
     property bool pair_supported: false
+    property string selected_testcoin
     onPair_supportedChanged: if (!pair_supported) webEngineViewPlaceHolder.visible = false
 
     function loadChart(right_ticker, left_ticker, force = false, source="livecoinwatch")
@@ -31,21 +32,29 @@ Item
 
         if (source == "livecoinwatch")
         {
+            selected_testcoin = ""
+            if (General.is_testcoin(left_ticker))
+            {
+                pair_supported = false
+                selected_testcoin = left_ticker
+                return
+            }
+            if (General.is_testcoin(right_ticker))
+            {
+                pair_supported = false
+                selected_testcoin = right_ticker
+                return
+            }
+
+            right_ticker = General.getChartTicker(right_ticker)
+            left_ticker = General.getChartTicker(left_ticker)
             if (right_ticker != "" && left_ticker != "")
             {
-                symbol = right_ticker+"-"+left_ticker
-
                 pair_supported = true
+                symbol = right_ticker+"-"+left_ticker
                 if (symbol === loaded_symbol && !force)
                 {
                     webEngineViewPlaceHolder.visible = true
-                    return
-                }
-                right_ticker = General.getChartTicker(right_ticker)
-                left_ticker = General.getChartTicker(left_ticker)
-                if (left_ticker == "" || right_ticker == "")
-                {
-                    pair_supported = false
                     return
                 }
                 chart_html = `
@@ -159,8 +168,16 @@ Item
 
         DefaultText
         {
-            visible: !pair_supported
-            text_value: qsTr("There is no chart data for this pair yet")
+            visible: !pair_supported && selected_testcoin == ""
+            text_value: qsTr("There is no chart data for this pair")
+            Layout.topMargin: 30
+            Layout.alignment: Qt.AlignCenter
+        }
+
+        DefaultText
+        {
+            visible: !pair_supported && selected_testcoin != ""
+            text_value: qsTr("There is no chart data for %1 (testcoin) pairs").arg(selected_testcoin)
             Layout.topMargin: 30
             Layout.alignment: Qt.AlignCenter
         }

--- a/atomic_defi_design/Dex/Exchange/ProView/TradingInfo/Main.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/TradingInfo/Main.qml
@@ -12,6 +12,7 @@ import "../../ProView"
 
 Widget
 {
+    width: 495
     property alias currentIndex: tabView.currentIndex
 
     title: qsTr("Trading Information")
@@ -63,10 +64,10 @@ Widget
 
     Rectangle
     {
-        Layout.fillWidth: true
         Layout.fillHeight: true
         color: Dex.CurrentTheme.floatingBackgroundColor
         radius: 10
+        Layout.preferredWidth: 495
 
         Qaterial.SwipeView
         {
@@ -86,12 +87,11 @@ Widget
                 {
                     id: chart
                     Layout.topMargin: 20
-                    Layout.leftMargin: 15
-                    Layout.rightMargin: 15
-                    Layout.fillWidth: true
+                    Layout.leftMargin: 10
+                    Layout.rightMargin: 10
                     Layout.fillHeight: true
-                    Layout.minimumWidth: 465
-                    Layout.minimumHeight: 180
+                    Layout.minimumWidth: 470
+                    Layout.minimumHeight: 200
                 }
 
                 PriceLineSimplified

--- a/atomic_defi_design/Dex/Exchange/ProView/TradingInfo/Main.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/TradingInfo/Main.qml
@@ -90,7 +90,8 @@ Widget
                     Layout.rightMargin: 15
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                    Layout.minimumWidth : 465
+                    Layout.minimumWidth: 465
+                    Layout.minimumHeight: 180
                 }
 
                 PriceLineSimplified

--- a/atomic_defi_design/Dex/Exchange/ProView/TradingInfo/Main.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/TradingInfo/Main.qml
@@ -79,25 +79,26 @@ Widget
             ColumnLayout
             {
                 Layout.fillHeight: true
+                Layout.fillWidth: true
                 spacing: 10
                 // Chart
                 Chart
                 {
                     id: chart
                     Layout.topMargin: 20
-                    Layout.leftMargin: 28
-                    Layout.rightMargin: 28
+                    Layout.leftMargin: 15
+                    Layout.rightMargin: 15
                     Layout.fillWidth: true
-                    Layout.preferredHeight: 310
-
+                    Layout.fillHeight: true
+                    Layout.minimumWidth : 465
                 }
 
                 PriceLineSimplified
                 {
                     id: price_line
                     Layout.bottomMargin: 20
-                    Layout.leftMargin: 28
-                    Layout.rightMargin: 28
+                    Layout.leftMargin: 20
+                    Layout.rightMargin: 20
                     Layout.fillWidth: true
                     Layout.fillHeight: true
                 }

--- a/atomic_defi_design/Dex/Exchange/Trade/ProView.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/ProView.qml
@@ -111,8 +111,8 @@ RowLayout
     {
         Layout.alignment: Qt.AlignTop
 
-        Layout.minimumWidth: selectors.visible || tradingInfo.visible ? 480 : -1
-        Layout.maximumWidth: (!orderBook.visible && !bestOrders.visible) || (!placeOrderForm.visible) ? -1 : 735
+        Layout.minimumWidth: selectors.visible || tradingInfo.visible ? 495 : -1
+        Layout.maximumWidth: (!orderBook.visible && !bestOrders.visible) || (!placeOrderForm.visible) ? -1 : 495
         Layout.fillWidth: true
 
         Layout.fillHeight: true

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -371,11 +371,8 @@ namespace atomic_dex
                 }
                 //! TODO: figure out why sometimes ZHTLC coins end up in here twice. When they do, without this check it crashes.
                 if (std::find(to_init.begin(), to_init.end(), ticker) != to_init.end()) {
-                    SPDLOG_DEBUG("Ticker {} is already in vector", ticker);
+                    // SPDLOG_DEBUG("Ticker {} is already in vector", ticker);
                     add_to_init = false;
-                }
-                else {
-                    SPDLOG_DEBUG("Ticker {} is not already in vector", ticker);
                 }
                 if (add_to_init) {
                     to_init.push_back(ticker);

--- a/src/core/atomicdex/api/komodo_prices/komodo.prices.cpp
+++ b/src/core/atomicdex/api/komodo_prices/komodo.prices.cpp
@@ -61,10 +61,6 @@ namespace atomic_dex::komodo_prices::api
         {
             x = provider::forex;
         }
-        else if (j == "nomics")
-        {
-            x = provider::nomics;
-        }
         else
         {
             x = provider::unknown;

--- a/src/core/atomicdex/api/komodo_prices/komodo.prices.hpp
+++ b/src/core/atomicdex/api/komodo_prices/komodo.prices.hpp
@@ -13,7 +13,6 @@ namespace atomic_dex::komodo_prices::api
         coingecko,
         coinpaprika,
         forex,
-        nomics,
         unknown
     };
 

--- a/src/core/atomicdex/config/coins.cfg.cpp
+++ b/src/core/atomicdex/config/coins.cfg.cpp
@@ -140,7 +140,6 @@ namespace atomic_dex
         cfg.minimal_claim_amount = cfg.is_claimable ? j.at("minimal_claim_amount").get<std::string>() : "0";
         cfg.coinpaprika_id       = j.contains("coinpaprika_id") ? j.at("coinpaprika_id").get<std::string>() : "test-coin";
         cfg.coingecko_id         = j.contains("coingecko_id") ? j.at("coingecko_id").get<std::string>() : "test-coin";
-        cfg.nomics_id            = j.contains("nomics_id") ? j.at("nomics_id").get<std::string>() : "test-coin";
         cfg.is_claimable         = j.count("is_claimable") > 0;
         cfg.is_custom_coin       = j.contains("is_custom_coin") ? j.at("is_custom_coin").get<bool>() : false;
         cfg.is_testnet           = j.contains("is_testnet") ? j.at("is_testnet").get<bool>() : false;

--- a/src/core/atomicdex/config/coins.cfg.cpp
+++ b/src/core/atomicdex/config/coins.cfg.cpp
@@ -140,6 +140,7 @@ namespace atomic_dex
         cfg.minimal_claim_amount = cfg.is_claimable ? j.at("minimal_claim_amount").get<std::string>() : "0";
         cfg.coinpaprika_id       = j.contains("coinpaprika_id") ? j.at("coinpaprika_id").get<std::string>() : "test-coin";
         cfg.coingecko_id         = j.contains("coingecko_id") ? j.at("coingecko_id").get<std::string>() : "test-coin";
+        cfg.livecoinwatch_id    = j.contains("livecoinwatch_id") ? j.at("livecoinwatch_id").get<std::string>() : "test-coin";
         cfg.is_claimable         = j.count("is_claimable") > 0;
         cfg.is_custom_coin       = j.contains("is_custom_coin") ? j.at("is_custom_coin").get<bool>() : false;
         cfg.is_testnet           = j.contains("is_testnet") ? j.at("is_testnet").get<bool>() : false;

--- a/src/core/atomicdex/config/coins.cfg.hpp
+++ b/src/core/atomicdex/config/coins.cfg.hpp
@@ -56,6 +56,7 @@ namespace atomic_dex
         bool                                        active{false};
         std::string                                 coinpaprika_id{"test-coin"};
         std::string                                 coingecko_id{"test-coin"};
+        std::string                                 livecoinwatch_id{"test-coin"};
         bool                                        is_custom_coin{false};
         std::string                                 type;
         std::optional<std::set<CoinType>> other_types;

--- a/src/core/atomicdex/config/coins.cfg.hpp
+++ b/src/core/atomicdex/config/coins.cfg.hpp
@@ -56,7 +56,6 @@ namespace atomic_dex
         bool                                        active{false};
         std::string                                 coinpaprika_id{"test-coin"};
         std::string                                 coingecko_id{"test-coin"};
-        std::string                                 nomics_id{"test-coin"};
         bool                                        is_custom_coin{false};
         std::string                                 type;
         std::optional<std::set<CoinType>> other_types;

--- a/src/core/atomicdex/models/qt.global.coins.cfg.model.cpp
+++ b/src/core/atomicdex/models/qt.global.coins.cfg.model.cpp
@@ -36,7 +36,6 @@ namespace
             {"ticker", QString::fromStdString(coin.ticker)},
             {"name", QString::fromStdString(coin.name)},
             {"type", QString::fromStdString(coin.type)},
-            {"nomics_id", QString::fromStdString(coin.nomics_id)},
             {"explorer_url", QString::fromStdString(coin.explorer_url)},
             {"tx_uri", QString::fromStdString(coin.tx_uri)},
             {"address_uri", QString::fromStdString(coin.address_url)},

--- a/src/core/atomicdex/models/qt.global.coins.cfg.model.cpp
+++ b/src/core/atomicdex/models/qt.global.coins.cfg.model.cpp
@@ -36,6 +36,7 @@ namespace
             {"ticker", QString::fromStdString(coin.ticker)},
             {"name", QString::fromStdString(coin.name)},
             {"type", QString::fromStdString(coin.type)},
+            {"livecoinwatch_id", QString::fromStdString(coin.livecoinwatch_id)},
             {"explorer_url", QString::fromStdString(coin.explorer_url)},
             {"tx_uri", QString::fromStdString(coin.tx_uri)},
             {"address_uri", QString::fromStdString(coin.address_url)},

--- a/src/core/atomicdex/pages/qt.trading.page.cpp
+++ b/src/core/atomicdex/pages/qt.trading.page.cpp
@@ -973,7 +973,7 @@ namespace atomic_dex
     bool
     trading_page::set_pair(bool is_left_side, const QString& changed_ticker)
     {
-        SPDLOG_INFO("Changed ticker: {}", changed_ticker.toStdString());
+        // SPDLOG_DEBUG("Changed ticker: {}", changed_ticker.toStdString());
         const auto* market_pair = get_market_pairs_mdl();
         auto        base        = market_pair->get_left_selected_coin();
         auto        rel         = market_pair->get_right_selected_coin();

--- a/src/core/atomicdex/services/price/komodo_prices/komodo.prices.provider.cpp
+++ b/src/core/atomicdex/services/price/komodo_prices/komodo.prices.provider.cpp
@@ -141,8 +141,6 @@ namespace atomic_dex
             return "coinpaprika";
         case komodo_prices::api::provider::forex:
             return "forex";
-        case komodo_prices::api::provider::nomics:
-            return "nomics";
         default:
             return "unknown";
         }


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/2238

To test: 
- check dex pro view chart. resize / maximise window. change pair. there should be no flicker or overflow.

We dont have i or this widget yet, though it uses tickers by default so it the ticker is supported a chart will display.
This has some known issues:
- The ticker may link to the wrong coin
![image](https://user-images.githubusercontent.com/35845239/229876380-d78d23a8-c25f-471d-a44c-bb54cd945562.png)
- the ticker may not be supported
![image](https://user-images.githubusercontent.com/35845239/229876594-9ce3aad4-fd30-4f29-9802-ce02e9f46a67.png)

Until we can compile a list of correct/working tickers, I'll add an exclusion list for coins known to be no good. Please list any you encounter in this PR.