### PR TITLE
remove timeout

### DIFF
--- a/src/core/atomicdex/api/mm2/mm2.client.cpp
+++ b/src/core/atomicdex/api/mm2/mm2.client.cpp
@@ -38,10 +38,10 @@ namespace
     {
         using namespace std::chrono_literals;
         
-        constexpr auto                          client_timeout = 30s;
+        //constexpr auto                          client_timeout = 30s;
         web::http::client::http_client_config   cfg;
 
-        cfg.set_timeout(client_timeout);
+        //cfg.set_timeout(client_timeout);
         return {FROM_STD_STR(atomic_dex::g_dex_rpc), cfg};
     }
 


### PR DESCRIPTION
timeouts should be handled by mm2
it has some timeouts set to a higher value anyway, like 60s for requests to RPC nodes
if ADEX Desktop times out the connection to mm2 earlier, we will never see the actual error from mm2