### PR TITLE
Revert "don't update max_taker_vol on every orderbook update"

### DIFF
--- a/src/core/atomicdex/pages/qt.trading.page.cpp
+++ b/src/core/atomicdex/pages/qt.trading.page.cpp
@@ -56,7 +56,7 @@ namespace atomic_dex
         {
             m_actions_queue.push(trading_actions::post_process_orderbook_finished);
             m_models_actions[orderbook_need_a_reset] = evt.is_a_reset;
-            //determine_max_volume();
+            determine_max_volume();
         }
     }
 } // namespace atomic_dex


### PR DESCRIPTION
This reverts commit 86b0620d968076f682f7392bc081eb552e5f261f.
unfortunately this breaks simple view, so it need to be reverted
simple view relies on orderbook update to update max_taker_vol