### PR TITLE
Lite theme contrast fixes

### DIFF
--- a/assets/themes/Default - Light/colors.json
+++ b/assets/themes/Default - Light/colors.json
@@ -2,13 +2,14 @@
     "accentColor": "#F0F2FFFF",
     "foregroundColor": "#456078FF",
     "backgroundColor": "#FCFCFCFF",
-    "backgroundColorDeep": "#FCFCFCFF",
+    "secondBackgroundColor": "#ECECECFF",
+    "backgroundColorDeep": "#ECECECFF",
 
     "busyIndicatorColor": "#5A68E6FF",
 
     "buttonColorDisabled": "#D8E3F8FF",
-    "buttonColorEnabled": "#F0F6FFFF",
-    "buttonColorHovered": "#D7E7FFFF",
+    "buttonColorEnabled": "#DDE6F2FF",
+    "buttonColorHovered": "#CDE1FFFF",
     "buttonColorPressed": "#B8D2F9FF",
     "buttonTextDisabledColor": "#D1D4DCFF",
     "buttonTextEnabledColor": "#456078FF",
@@ -21,8 +22,8 @@
     "buttonSecondaryColorPressed":  "#B8D2F9FF",
 
     "buttonCancelColorDisabled": "#D8E3F8FF",
-    "buttonCancelColorEnabled":  "#F0F6FFFF",
-    "buttonCancelColorHovered":  "#D7E7FFFF",
+    "buttonCancelColorEnabled":  "#DDE6F2FF",
+    "buttonCancelColorHovered":  "#CDE1FFFF",
     "buttonCancelColorPressed":  "#B8D2F9FF",
 
     "gradientButtonStartColor": "#5A68E6FF",

--- a/atomic_defi_design/Dex/Addressbook/NewContactPopup.qml
+++ b/atomic_defi_design/Dex/Addressbook/NewContactPopup.qml
@@ -6,6 +6,7 @@ import QtQuick.Layouts 1.15
 import "../Components"
 import "../Constants"
 import Dex.Components 1.0 as Dex
+import Dex.Themes 1.0 as Dex
 
 Dex.Popup
 {
@@ -14,6 +15,7 @@ Dex.Popup
     height: 88
     onOpened: nameField.forceActiveFocus()
     onClosed: nameField.text = ""
+    bgColor: Dex.CurrentTheme.innerBackgroundColor 
 
     contentItem: Column
     {

--- a/atomic_defi_design/Dex/Components/DefaultButton.qml
+++ b/atomic_defi_design/Dex/Components/DefaultButton.qml
@@ -3,6 +3,5 @@ import "../Constants"
 import App 1.0
 
 // Add button
-DexButton {
-
-}
+DexAppButton {}
+ 

--- a/atomic_defi_design/Dex/Components/DefaultPopup.qml
+++ b/atomic_defi_design/Dex/Components/DefaultPopup.qml
@@ -2,14 +2,16 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.15 //> Popup
 
+import Dex.Themes 1.0 as Dex
 Popup
 {
     id: popup
+    property color bgColor: Dex.CurrentTheme.floatingBackgroundColor
 
     y: parent.height
     x: (parent.width / 2) - (width / 2)
 
     closePolicy: Popup.CloseOnPressOutsideParent | Popup.CloseOnEscape
 
-    background: FloatingBackground { }
+    background: FloatingBackground { color: bgColor } 
 }

--- a/atomic_defi_design/Dex/Components/DexButton.qml
+++ b/atomic_defi_design/Dex/Components/DexButton.qml
@@ -1,6 +1,0 @@
-import QtQuick 2.15
-import "../Constants"
-import App 1.0
-
-// Add button
-DexAppButton {}

--- a/atomic_defi_design/Dex/Components/DexTextField.qml
+++ b/atomic_defi_design/Dex/Components/DexTextField.qml
@@ -11,7 +11,8 @@ TextField
     property alias left_text: left_text.text_value
     property alias right_text: right_text.text_value
     property alias radius: background.radius
-    property alias backgroundColor: background.color
+    property color backgroundColor: Dex.CurrentTheme.textFieldBackgroundColor
+    property color backgroundColorActive: Dex.CurrentTheme.textFieldActiveBackgroundColor
     property bool forceFocus: false
 
     font: DexTypo.body2
@@ -30,7 +31,7 @@ TextField
     background: DefaultRectangle
     {
         id: background
-        color: text_field.focus ? Dex.CurrentTheme.textFieldActiveBackgroundColor : Dex.CurrentTheme.textFieldBackgroundColor
+        color: text_field.focus ? backgroundColorActive : backgroundColor
         radius: 18
         anchors.fill: parent
     }

--- a/atomic_defi_design/Dex/Components/PaginationButton.qml
+++ b/atomic_defi_design/Dex/Components/PaginationButton.qml
@@ -1,6 +1,6 @@
 import "../Components"
 
-DexButton
+DexAppButton
 {
     font.pixelSize: 12
 }


### PR DESCRIPTION
Fixes some bad contrast coloring in lite theme for buttons and "add contact" pop up.
Also removes an obsolete/duplicate component.
To test:
- Use lite theme
- Check the pop up in addressbook when you press "new contact" button. The background of the pop up should be different color to the input field.
- Check the "refresh" button in the "Claim KMD rewards modal".  It should be clearly visible and not the same color as the background.