### PR TITLE
Set BTC-segwit to wallet only

### DIFF
--- a/src/core/atomicdex/constants/dex.constants.hpp
+++ b/src/core/atomicdex/constants/dex.constants.hpp
@@ -11,7 +11,6 @@ namespace atomic_dex
         g_primary_dex_coin,
         g_second_primary_dex_coin,
         "VOTE2023",
-        "KIP0001",
         "BTC"
     };
     inline const std::vector<std::string> g_wallet_only_coins{
@@ -32,7 +31,7 @@ namespace atomic_dex
         "REVS",
         "SUPERNET",
         "XPM",
-        "KIP0001",
+        "BTC-segwit",
         "VOTE2023",
         "ATOM"
     };


### PR DESCRIPTION
Due to variation in the version of API used between desktop and other GUIs / LPs, there have been cases of failed swaps involving `BTC-segwit` between desktop and other users. This will be resolved once we update to the latest API in 0.5.8, but until then we can make `BTC-Segwit` wallet only to avoid failed swaps.

To test:
- Login and activate `BTC-segwit`
- You should be unable to select `BTC-segwit` for trading