### PR TITLE
handle button where no notifications

### DIFF
--- a/atomic_defi_design/Dex/Dashboard/NotificationsModal.qml
+++ b/atomic_defi_design/Dex/Dashboard/NotificationsModal.qml
@@ -622,8 +622,8 @@ DexPopup
         }
 
         OutlineButton
-        {
-            text: qsTr('Mark all as read')
+        {            
+            text: notifications_list.length !== 0 ? qsTr('Mark all as read') : qsTr('Close')
             height: 40
             width: 260
             Layout.alignment: Qt.AlignHCenter


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/atomicDEX-Desktop/issues/2258

To test: View your notifications when the list is empty. The button should have different text as below:


https://user-images.githubusercontent.com/35845239/231704791-66722939-3196-4793-8aa7-f6e86b11d0f9.mp4

