### PR TITLE
Extend price loop from 2 min to 5 min

### DIFF
--- a/src/core/atomicdex/services/price/global.provider.cpp
+++ b/src/core/atomicdex/services/price/global.provider.cpp
@@ -177,9 +177,9 @@ namespace atomic_dex
 
         const auto now = std::chrono::high_resolution_clock::now();
         const auto s   = std::chrono::duration_cast<std::chrono::seconds>(now - m_update_clock);
-        if (s >= 2min)
+        if (s >= 5min)
         {
-            SPDLOG_INFO("2min spend - refreshing provider");
+            SPDLOG_INFO("[global_price_service::update()] - 5min elapsed, updating providers");
             this->on_force_update_providers({});
             m_update_clock = std::chrono::high_resolution_clock::now();
         }


### PR DESCRIPTION
It was reported in Discord that the following was showing up in logs:

```
[18:20:58] [error] [coinpaprika.hpp:124] [2355805]: exception caught: error[[json.exception.out_of_range.403] key 'base_currency_id' not found], body: {"error": "This plan has 25000 monthly requests limit, your requests rate is: 25001.152610. Check plans on coinpaprika.com/api"}
```

Previously this was in a loop every 2 minutes. I've extended it to 5 minutes.