### PR TITLE
filter out zero value transactions

### DIFF
--- a/src/core/atomicdex/pages/qt.wallet.page.cpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.cpp
@@ -978,15 +978,23 @@ namespace atomic_dex
         {
             std::error_code ec;
             t_transactions  transactions = m_system_manager.get_system<mm2_service>().get_tx_history(ec);
+            t_transactions  to_init;
+            for (auto&& cur_tx: transactions)
+            {
+                if (safe_float(cur_tx.total_amount) != 0)
+                {
+                    to_init.push_back(cur_tx);
+                }
+            }
             if (m_transactions_mdl->rowCount() == 0)
             {
                 //! insert all transactions
-                m_transactions_mdl->init_transactions(transactions);
+                m_transactions_mdl->init_transactions(to_init);
             }
             else
             {
                 //! Update tx (only unconfirmed) or insert (new tx)
-                m_transactions_mdl->update_or_insert_transactions(transactions);
+                m_transactions_mdl->update_or_insert_transactions(to_init);
             }
             if (ec)
             {


### PR DESCRIPTION
Before:
![image](https://github.com/KomodoPlatform/atomicDEX-Desktop/assets/35845239/99c705f7-9a98-4ba4-9242-fb29379d8519)

After:
![image](https://github.com/KomodoPlatform/atomicDEX-Desktop/assets/35845239/8dfbe41e-d3c6-45dd-a1f2-8e888b3c575d)

To test:
- Load an older version of the app and check if you have any zero value transactions in BUSD, USDC or other stablecoins.
- If you find one, exit app, and relaunch a build form this branch.
- check the same coin's transaction history - the zero value transaction should not be visible.