### PR TITLE
Enhanced antidote for poison tx 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # This file is used to ignore files which are generated
 # ----------------------------------------------------------------------------
-
+.vscode/
 *~
 *.autosave
 *.a

--- a/assets/config/cfg.json
+++ b/assets/config/cfg.json
@@ -1,5 +1,6 @@
 {
   "notification_enabled": true,
+  "spamfilter_enabled": false,
   "current_currency": "USD",
   "current_fiat": "USD",
   "current_currency_sign": "$",

--- a/atomic_defi_design/Dex/Settings/SettingModal.qml
+++ b/atomic_defi_design/Dex/Settings/SettingModal.qml
@@ -205,6 +205,7 @@ Qaterial.Dialog
                             topPadding: 10
                             spacing: 15
 
+                            // Notifications toggle
                             RowLayout
                             {
                                 width: parent.width - 30
@@ -229,6 +230,32 @@ Qaterial.Dialog
                                 }
                             }
 
+                            // Spam filter toggle
+                            RowLayout
+                            {
+                                width: parent.width - 30
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                height: 50
+
+                                DexLabel
+                                {
+                                    Layout.alignment: Qt.AlignVCenter
+                                    Layout.fillWidth: true
+                                    font: DexTypo.subtitle1
+                                    text: qsTr("Hide Poison Transactions in History")
+                                }
+
+                                Item { Layout.fillWidth: true }
+
+                                DexSwitch
+                                {
+                                    Layout.alignment: Qt.AlignVCenter
+                                    Component.onCompleted: checked = API.app.settings_pg.spamfilter_enabled
+                                    onCheckedChanged: API.app.settings_pg.spamfilter_enabled = checked
+                                }
+                            }
+
+                            // Max Coins Dropdown
                             RowLayout
                             {
                                 width: parent.width - 30

--- a/atomic_defi_design/Dex/Support/SupportModal.qml
+++ b/atomic_defi_design/Dex/Support/SupportModal.qml
@@ -29,7 +29,7 @@ Qaterial.Dialog
     topPadding: 30
     bottomPadding: 30
     anchors.centerIn: parent
-
+    
     dim: true
     modal: true
     title: "Support"
@@ -140,6 +140,19 @@ For this reason, we recommend cancelling orders before closing %1, or reviewing 
 2. Both makers and takers will need to pay normal network fees to the involved blockchains when making atomic swap transactions.
 
 Network fees can vary greatly depending on your selected trading pair.").arg(API.app_name)
+                }
+
+                // TODO: Update link to the KP blog when relevent article available.
+                FAQLine
+                {
+                    title: qsTr("I see a transaction in my wallet that was marked as 'poison'. What does this mean?")
+                    text: qsTr('Address poisoning is a relatively new tye of phishing attack, where a malicious actor aims to trick you into sending funds to an address that you did not intend to send funds to.
+
+This is often done by sending a zero value transaction to your wallet from an address which looks very similar to your actual address, with the exact same letters at the start and end. This transaction will then appear in your transaction history, with the scammer hoping you will mistake the fake address for your own and send funds to it.
+
+To protect you from this, %1 will mark any transaction that it detects as potentially being a poison transaction with a "poison" label. You should always be careful to confirm any address you send funds to is correct.
+
+There is a toggle in settings where you can turn on/off the display of these transactions.').arg(API.app_name)
                 }
 
                 FAQLine

--- a/atomic_defi_design/Dex/Wallet/Main.qml
+++ b/atomic_defi_design/Dex/Wallet/Main.qml
@@ -42,6 +42,7 @@ Item
     Layout.fillHeight: true
     Layout.fillWidth: true
 
+    // TODO: Move this section for the coin summary bar at the top to its own component
     ColumnLayout
     {
         id: wallet_layout
@@ -970,13 +971,15 @@ Item
                         GradientStop { position: 1; color: Dex.CurrentTheme.backgroundColor }
                     }
                 }
-
+                
+                // Transactions history table
                 Transactions
                 {
                     width: parent.width
                     height: parent.height
                 }
 
+                // Placeholder if no tx history available, or being fetched.
                 ColumnLayout
                 {
                     visible: current_ticker_infos.tx_state !== "InProgress" && transactions_mdl.length === 0
@@ -1011,6 +1014,7 @@ Item
                         visible: api_wallet_page.tx_fetching_busy
                     }
 
+                    // When no tx history available, or being fetched, show a button to open the explorer.
                     DefaultText
                     {
                         id: explorerLink

--- a/atomic_defi_design/Dex/Wallet/TransactionDetailsModal.qml
+++ b/atomic_defi_design/Dex/Wallet/TransactionDetailsModal.qml
@@ -18,6 +18,7 @@ MultipageModal
     function reset() { }
 
     property var details
+    property bool is_spam: !details ? false : details.amount == 0
 
     onClosed:
     {
@@ -28,6 +29,30 @@ MultipageModal
     MultipageModalContent
     {
         titleText: qsTr("Transaction Details")
+
+        // Warning for spam/poison transactions
+        DefaultText
+        {
+            id: warning_text
+            visible: is_spam
+            Layout.alignment: Qt.AlignVCenter
+            Layout.fillWidth: true
+            wrapMode: Label.Wrap
+            color: Style.colorOrange
+            text_value: qsTr("This transaction has been identified as a potential address poisoning attack.")
+        }
+
+        // Warning for spam/poison transactions
+        DefaultText
+        {
+            id: warning_text2
+            visible: is_spam
+            Layout.alignment: Qt.AlignVCenter
+            Layout.fillWidth: true
+            wrapMode: Label.Wrap
+            color: Style.colorOrange
+            text_value: qsTr("Please see the Support FAQ for more information.")
+        }
 
         // Transaction Hash
         TitleText

--- a/atomic_defi_design/Dex/Wallet/TransactionDetailsModal.qml
+++ b/atomic_defi_design/Dex/Wallet/TransactionDetailsModal.qml
@@ -71,7 +71,7 @@ MultipageModal
             text_box_width: 600
             text_value: !details ? "" : details.tx_hash
             linkURL: !details ? "" :General.getTxExplorerURL(api_wallet_page.ticker, details.tx_hash, false)
-            onCopyNotificationTitle: qsTr("%1 txid", "TICKER").arg(api_wallet_page.ticker)
+            onCopyNotificationTitle:  qsTr("%1 txid", "TICKER").arg(api_wallet_page.ticker)
             onCopyNotificationMsg: qsTr("copied to clipboard.")
             privacy: true
         }
@@ -103,7 +103,7 @@ MultipageModal
             model: !details ? [] :
                     details.from
             linkURL: !details ? "" :General.getAddressExplorerURL(api_wallet_page.ticker, details.from)
-            onCopyNotificationTitle: qsTr("From address")
+            onCopyNotificationTitle: is_spam ? "" : qsTr("From address")
         }
 
         AddressList
@@ -117,7 +117,7 @@ MultipageModal
                     :  details.to.length > 1
                     ? General.getAddressExplorerURL(api_wallet_page.ticker, General.arrayExclude(details.to, details.from[0]))
                     : General.getAddressExplorerURL(api_wallet_page.ticker, details.to)
-            onCopyNotificationTitle: qsTr("To address")
+            onCopyNotificationTitle: is_spam ? "" : qsTr("To address")
         }
 
         // Date

--- a/atomic_defi_design/Dex/Wallet/Transactions.qml
+++ b/atomic_defi_design/Dex/Wallet/Transactions.qml
@@ -22,10 +22,11 @@ Dex.ListView
 
     model: transactions_mdl.proxy_mdl
 
-    // Row
+    // Transaction Row
     delegate: Dex.Rectangle
     {
         id: rectangle
+        property bool is_spam: amount == 0 
         width: list.width
         height: row_height
         radius: 0
@@ -64,13 +65,13 @@ Dex.ListView
                     visible: transaction_note !== ""
                 }
 
-
+                // When a spam / poison tx, we show a warning icon
                 Qaterial.Icon
                 {
                     id: received_icon
                     size: 16
-                    icon: am_i_sender ? Qaterial.Icons.arrowTopRight : Qaterial.Icons.arrowBottomRight
-                    color: am_i_sender ? Dex.CurrentTheme.warningColor : Dex.CurrentTheme.okColor
+                    icon: is_spam ? Qaterial.Icons.radioactive : am_i_sender ? Qaterial.Icons.arrowTopRight : Qaterial.Icons.arrowBottomRight
+                    color: is_spam ? Style.colorOrange : am_i_sender ? Dex.CurrentTheme.warningColor : Dex.CurrentTheme.okColor
                 }
 
                 // Description
@@ -78,8 +79,9 @@ Dex.ListView
                 {
                     id: description
                     horizontalAlignment: Qt.AlignLeft
-                    text_value: am_i_sender ? qsTr("Sent") : qsTr("Received")
+                    text_value: is_spam ? qsTr("Poison") : am_i_sender ? qsTr("Sent") : qsTr("Received")
                     font.pixelSize: Style.textSizeSmall3
+                    color: is_spam ? Style.colorOrange : am_i_sender ? Dex.CurrentTheme.warningColor : Dex.CurrentTheme.okColor
                 }
             }
 
@@ -97,7 +99,7 @@ Dex.ListView
 
                 }
                 font.pixelSize: description.font.pixelSize
-                color: am_i_sender ? Dex.CurrentTheme.warningColor : Dex.CurrentTheme.okColor
+                color: is_spam ? Style.colorWhite7 : am_i_sender ? Dex.CurrentTheme.warningColor : Dex.CurrentTheme.okColor
                 privacy: true
             }
 
@@ -108,8 +110,9 @@ Dex.ListView
                 horizontalAlignment: Text.AlignRight
                 text_value: General.formatFiat(!am_i_sender, amount_fiat, API.app.settings_pg.current_currency)
                 font.pixelSize: description.font.pixelSize
-                color: crypto_amount.color
+                color: is_spam ? Style.colorWhite7 : crypto_amount.color
                 privacy: true
+                
             }
 
             // Fee
@@ -121,6 +124,7 @@ Dex.ListView
                                                                            current_ticker_infos.fee_ticker + " " + qsTr("fees"))
                 font.pixelSize: description.font.pixelSize
                 privacy: true
+                color: is_spam ? Style.colorWhite7 : crypto_amount.color
             }
 
             // Date
@@ -131,6 +135,7 @@ Dex.ListView
                 font.pixelSize: description.font.pixelSize
                 text_value: !date || unconfirmed ? qsTr("Unconfirmed") : date
                 privacy: true
+                color: is_spam ? Style.colorWhite7 : crypto_amount.color
             }
         }
     }

--- a/src/core/atomicdex/config/app.cfg.cpp
+++ b/src/core/atomicdex/config/app.cfg.cpp
@@ -48,6 +48,7 @@ namespace
         config_json_data["current_fiat_sign"]     = config.current_fiat_sign;
         config_json_data["available_signs"]       = config.available_currency_signs;
         config_json_data["notification_enabled"]  = config.notification_enabled;
+        config_json_data["spamfilter_enabled"]    = config.spamfilter_enabled;
 
         file.close();
 
@@ -71,6 +72,15 @@ namespace atomic_dex
         j.at("available_signs").get_to(config.available_currency_signs);
         j.at("current_fiat_sign").get_to(config.current_fiat_sign);
         j.at("notification_enabled").get_to(config.notification_enabled);
+
+        if (j.contains("spamfilter_enabled"))
+        {
+            j.at("spamfilter_enabled").get_to(config.spamfilter_enabled);
+        }
+        else
+        {
+            config.spamfilter_enabled = true;
+        }
     }
 
     void
@@ -79,6 +89,16 @@ namespace atomic_dex
         if (config.notification_enabled != is_enabled)
         {
             config.notification_enabled = is_enabled;
+            upgrade_cfg(config);
+        }
+    }
+
+    void
+    change_spamfilter_status(cfg& config, bool is_enabled)
+    {
+        if (config.spamfilter_enabled != is_enabled)
+        {
+            config.spamfilter_enabled = is_enabled;
             upgrade_cfg(config);
         }
     }

--- a/src/core/atomicdex/config/app.cfg.hpp
+++ b/src/core/atomicdex/config/app.cfg.hpp
@@ -31,12 +31,14 @@ namespace atomic_dex
         std::vector<std::string>                     available_fiat;
         std::vector<std::string>                     possible_currencies;
         bool                                         notification_enabled;
+        bool                                         spamfilter_enabled{false};
     };
 
     void               from_json(const nlohmann::json& j, cfg& config);
     void               change_currency(cfg& config, const std::string& new_currency);
     void               change_fiat(cfg& config, const std::string& new_fiat);
     void               change_notification_status(cfg& config, bool is_enabled);
+    void               change_spamfilter_status(cfg& config, bool is_enabled);
     [[nodiscard]] bool is_this_currency_a_fiat(const cfg& config, const std::string& currency);
     cfg                load_cfg();
     std::string        retrieve_sign_from_ticker(const cfg& config, const std::string& currency);

--- a/src/core/atomicdex/pages/qt.settings.page.cpp
+++ b/src/core/atomicdex/pages/qt.settings.page.cpp
@@ -32,6 +32,7 @@
 #include "atomicdex/models/qt.global.coins.cfg.model.hpp"
 #include "atomicdex/pages/qt.portfolio.page.hpp"
 #include "atomicdex/pages/qt.settings.page.hpp"
+#include "atomicdex/pages/qt.wallet.page.hpp"
 #include "atomicdex/services/mm2/mm2.service.hpp"
 #include "atomicdex/services/price/coingecko/coingecko.wallet.charts.hpp"
 #include "atomicdex/services/price/global.provider.hpp"
@@ -145,8 +146,13 @@ namespace atomic_dex
     {
         if (m_config.spamfilter_enabled != is_enabled)
         {
+            
+            auto& mm2       = m_system_manager.get_system<mm2_service>();
+            auto& wallet_pg = m_system_manager.get_system<wallet_page>();
+            QString ticker  = QString::fromStdString(mm2.get_current_ticker());
             change_spamfilter_status(m_config, is_enabled);
             emit onSpamFilterEnabledChanged();
+            wallet_pg.set_current_ticker(ticker, true);
         }
     }
 

--- a/src/core/atomicdex/pages/qt.settings.page.cpp
+++ b/src/core/atomicdex/pages/qt.settings.page.cpp
@@ -136,6 +136,20 @@ namespace atomic_dex
         emit onLangChanged();
     }
 
+    bool atomic_dex::settings_page::is_spamfilter_enabled() const
+    {
+        return m_config.spamfilter_enabled;
+    }
+
+    void settings_page::set_spamfilter_enabled(bool is_enabled)
+    {
+        if (m_config.spamfilter_enabled != is_enabled)
+        {
+            change_spamfilter_status(m_config, is_enabled);
+            emit onSpamFilterEnabledChanged();
+        }
+    }
+
     bool atomic_dex::settings_page::is_notification_enabled() const
     {
         return m_config.notification_enabled;

--- a/src/core/atomicdex/pages/qt.settings.page.hpp
+++ b/src/core/atomicdex/pages/qt.settings.page.hpp
@@ -45,6 +45,7 @@ namespace atomic_dex
         Q_PROPERTY(QString  current_fiat_sign               READ get_current_fiat_sign                                                          NOTIFY onFiatSignChanged)
         Q_PROPERTY(QString  current_fiat                    READ get_current_fiat                   WRITE set_current_fiat                      NOTIFY onFiatChanged)
         Q_PROPERTY(bool     notification_enabled            READ is_notification_enabled            WRITE set_notification_enabled              NOTIFY onNotificationEnabledChanged)
+        Q_PROPERTY(bool     spamfilter_enabled              READ is_spamfilter_enabled              WRITE set_spamfilter_enabled                NOTIFY onSpamFilterEnabledChanged)
         Q_PROPERTY(QVariant custom_token_data               READ get_custom_token_data              WRITE set_custom_token_data                 NOTIFY customTokenDataChanged)
         Q_PROPERTY(bool     fetching_custom_token_data_busy READ is_fetching_custom_token_data_busy WRITE set_fetching_custom_token_data_busy   NOTIFY customTokenDataStatusChanged)
         Q_PROPERTY(bool     fetching_priv_keys_busy         READ is_fetching_priv_key_busy          WRITE set_fetching_priv_key_busy            NOTIFY privKeyStatusChanged)
@@ -82,6 +83,8 @@ namespace atomic_dex
         [[nodiscard]] QString                   get_current_fiat() const;
         [[nodiscard]] bool                      is_notification_enabled() const;
         void                                    set_notification_enabled(bool is_enabled);
+        [[nodiscard]] bool                      is_spamfilter_enabled() const;
+        void                                    set_spamfilter_enabled(bool is_enabled);
         void                                    set_current_currency(const QString& current_currency);
         void                                    set_current_fiat(const QString& current_fiat);
         [[nodiscard]] bool                      is_fetching_custom_token_data_busy() const;
@@ -124,6 +127,7 @@ namespace atomic_dex
         void onFiatSignChanged();
         void onFiatChanged();
         void onNotificationEnabledChanged();
+        void onSpamFilterEnabledChanged();
         void customTokenDataChanged();
         void customTokenDataStatusChanged();
         void privKeyStatusChanged();

--- a/src/core/atomicdex/pages/qt.wallet.page.cpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.cpp
@@ -977,14 +977,22 @@ namespace atomic_dex
         if (!evt.with_error && QString::fromStdString(evt.ticker) == get_current_ticker())
         {
             std::error_code ec;
+            const auto& settings         = m_system_manager.get_system<settings_page>();
             t_transactions  transactions = m_system_manager.get_system<mm2_service>().get_tx_history(ec);
             t_transactions  to_init;
-            for (auto&& cur_tx: transactions)
+            if (settings.is_spamfilter_enabled())
             {
-                if (safe_float(cur_tx.total_amount) != 0)
+                for (auto&& cur_tx: transactions)
                 {
-                    to_init.push_back(cur_tx);
+                    if (safe_float(cur_tx.total_amount) != 0)
+                    {
+                        to_init.push_back(cur_tx);
+                    }
                 }
+            }
+            else
+            {
+                to_init = transactions;
             }
             if (m_transactions_mdl->rowCount() == 0)
             {

--- a/src/core/atomicdex/pages/qt.wallet.page.cpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.cpp
@@ -107,11 +107,11 @@ namespace atomic_dex
         return QString::fromStdString(mm2_system.get_current_ticker());
     }
 
-    void wallet_page::set_current_ticker(const QString& ticker)
+    void wallet_page::set_current_ticker(const QString& ticker, bool force)
     {
         auto& mm2_system = m_system_manager.get_system<mm2_service>();
         auto  coin_info  = mm2_system.get_coin_info(ticker.toStdString());
-        if (mm2_system.set_current_ticker(ticker.toStdString()))
+        if (mm2_system.set_current_ticker(ticker.toStdString()) || force)
         {
             SPDLOG_INFO("new ticker: {}", ticker.toStdString());
             m_transactions_mdl->reset();

--- a/src/core/atomicdex/pages/qt.wallet.page.hpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.hpp
@@ -30,7 +30,7 @@ namespace atomic_dex
         // Getters/Setters
         [[nodiscard]] transactions_model* get_transactions_mdl() const;
         [[nodiscard]] QString             get_current_ticker() const;
-        void                              set_current_ticker(const QString& ticker);
+        void                              set_current_ticker(const QString& ticker, bool force = false);
         [[nodiscard]] QVariant            get_ticker_infos() const;
         [[nodiscard]] bool                is_broadcast_busy() const;
         void                              set_broadcast_busy(bool status);


### PR DESCRIPTION
**Changelog:**
- added toggle in settings to show/hide poison tx display in history
- refresh tx list on setting change
- modified styles for poison tx rows
- added warning to tx details modal for poison tx
- hide address copy buttons in tx details modal for poison tx
- add section in FAQ for more info about tx tagged as poison.

**Demo:**

https://github.com/KomodoPlatform/atomicDEX-Desktop/assets/35845239/7cb988bb-5cdc-42d2-8c08-843dc344eb66

**To Test**
- Load release v0.5.7 and check if you have any zero value transactions in BUSD, USDC or other stablecoin tokens.
- If you find one, exit app, and relaunch a build form this branch.
- Check the same coin's transaction history - the zero value transaction should not be tagged as poison.
- Confirm warning is displayed in tx details modal for poison tx
- Confirm copy buttons for addresses hidden in tx details modal for poison tx
- Go to settings, toggle to hide the poison tx
- Exit settings, confirm poison tx hidden
- Go to settings, toggle to show the poison tx
- Exit settings, confirm poison tx visible again