### PR TITLE
Use cmake 3.25.0 so CI/CD builds

### DIFF
--- a/ci_tools_atomic_dex/ci_scripts/windows_script.ps1
+++ b/ci_tools_atomic_dex/ci_scripts/windows_script.ps1
@@ -6,7 +6,7 @@ iwr -useb 'https://raw.githubusercontent.com/scoopinstaller/install/master/insta
 #Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh') -RunAsAdmin
 scoop install llvm --global
 scoop install ninja --global
-scoop install cmake@3.22.0 --global
+scoop install cmake@3.25.0 --global
 scoop install git --global
 scoop install 7zip  --global
 scoop cache rm 7zip


### PR DESCRIPTION
Prior builld attempt at https://github.com/KomodoPlatform/atomicDEX-Desktop/actions/runs/5198246870/jobs/9374119909#step:20:124 failed due to 404 error on url. 

To test:
- Look at the actions workflow for this PR. 
- Did it build windows without errors? If yes, approve.